### PR TITLE
remove nix-env

### DIFF
--- a/nix.html
+++ b/nix.html
@@ -93,7 +93,7 @@
                                 </ul>
                                 <p>It is important that these remain consistent across compatible apps and the Holochain Core.</p>
                                 <p>The Holonix repository tracks standard, shared dependencies for all of the scenarios in which we use NixOS. Typically you won&rsquo;t need to interact with Holonix directly.</p>
-                                <p>The main Nix tool used in Holochain development workflows is <span class="inline-code">nix-shell</span>, a managed Bash shell that overlays a new environment and set of tools on top of your existing environment</p>
+                                <p>The main Nix tool used in Holochain development workflows is <span class="inline-code">nix-shell</span>, a managed Bash shell that overlays a new environment and set of tools on top of your existing environment.</p>
                                 <p>Many popular package management tools only target a single OS. NixOS package management supports most OSes.</p>
                                 <p>The full suite of Nix tooling is broad and deep. There&rsquo;s even a dedicated OS and functional programming language. Learn more with the <a href="https://nixos.wiki/wiki/Main_Page" target="_blank" rel="noopener">NixOS Wiki</a> or the <a href="https://nixos.org/nixos/nix-pills/" target="_blank" rel="noopener">Pills</a> Tutorial. The community IRC chat at <span class="inline-code">#nixos</span> on freenode is active and helpful.</p>
                                 <br><h2 class="section-title" id="nix-shell"><span class="inline-code">nix-shell</span></h2><br>
@@ -102,12 +102,6 @@
                                 <p>You can extend the master <span class="inline-code">default.nix</span> file or use it directly from <a href="https://holochain.love/" target="_blank" rel="noopener">https://holochain.love</a>. Opening a shell from holochain.love downloads updates automatically. The initial run will take some time to download and build. It gets much faster on subsequent runs.</p>
                                 <p><span class="inline-code">nix-shell</span> cleans up everything it added when you exit. You need to re-enter the shell each time you want to work.</p>
                                   <p><em>Note: The files are cached locally on your machine, so they will not be re-downloaded or rebuilt the next time you enter the shell.</em></p>
-                                <h4 id="Troubleshooting">Troubleshooting</h4>
-                                <p>By default, <span class="inline-code">nix-shell</span> only adds new things to your bash shell. Your existing setup could contain dependencies that override <span class="inline-code">nix-shell</span> and conflict with expectations.</p>
-                                <p>The following command tells <span class="inline-code">nix-shell</span> to attempt to isolate common conflicts.</p>
-                                <p><code>nix-shell --pure</code></p>
-                                  <p><em>Try this option first if you&rsquo;re seeing errors where others are not.</em></p>
-                                <p>The &ldquo;nix pod&rdquo; in Holochain core isolates more aggressively for debugging.</p>
                             </div>
 
                         </section>

--- a/nix.html
+++ b/nix.html
@@ -44,12 +44,10 @@
     .copy-confirmation {
         margin-left: 10px;
     }
-
     .code-long .copy-to-clipboard { margin: 5px 0 0 0; display: inline-block; }
     .inline-code { padding: 2px 5px; background: #EEE; font-style: normal; font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New; }
     p em { margin: 7px 0; padding: 7px 0 7px 10px; color: #888; font-style: normal; border-left: 4px solid #DDD; display: block; }
     p.button-hide .copy-to-clipboard { display: none; }
-
 </style>
 
 <div class="page-wrapper">
@@ -88,35 +86,28 @@
                                 <p>NixOS development tools run on many operating systems. NixOS is also the OS we use in our automated testing and our HoloPorts.</p>
                                 <p>The main components of the tooling for Holochain development are:</p>
                                 <ul>
-                                  <li>The <a href="https://www.rust-lang.org/" target="_blank" rel="noopener">Rust</a> programming language</li>
-                                  <li><a href="https://nodejs.org/en/" target="_blank" rel="noopener">NodeJS</a> and <a href="https://www.npmjs.com/" target="_blank" rel="noopener">npm</a></li>
+                                  <li>The <a href="https://www.rust-lang.org/" target="_blank" rel="noopener">Rust</a> programming language</li>
+                                  <li><a href="https://nodejs.org/en/" target="_blank" rel="noopener">NodeJS</a> and <a href="https://www.npmjs.com/" target="_blank" rel="noopener">npm</a></li>
                                   <li>Cryptographic libraries</li>
                                   <li>Common automations and scripts</li>
                                 </ul>
                                 <p>It is important that these remain consistent across compatible apps and the Holochain Core.</p>
                                 <p>The Holonix repository tracks standard, shared dependencies for all of the scenarios in which we use NixOS. Typically you won&rsquo;t need to interact with Holonix directly.</p>
-                                <p>The main Nix tools used in Holochain development workflows are:</p>
-                                <ul>
-                                  <li><span class="inline-code">nix-shell</span>, a managed Bash shell that overlays a new environment and set of tools on top of your existing environment</li>
-                                  <li><span class="inline-code">nix-env</span>, a cross-platform package manager that installs the tools right into your existing environment</li>
-                                </ul>
+                                <p>The main Nix tool used in Holochain development workflows is <span class="inline-code">nix-shell</span>, a managed Bash shell that overlays a new environment and set of tools on top of your existing environment</p>
                                 <p>Many popular package management tools only target a single OS. NixOS package management supports most OSes.</p>
-                                <p>The full suite of Nix tooling is broad and deep. There&rsquo;s even a dedicated OS and functional programming language. Learn more with the <a href="https://nixos.wiki/wiki/Main_Page" target="_blank" rel="noopener">NixOS Wiki</a> or the <a href="https://nixos.org/nixos/nix-pills/" target="_blank" rel="noopener">Pills</a> Tutorial. The community IRC chat at <span class="inline-code">#nixos</span> on freenode is active and helpful.</p>
+                                <p>The full suite of Nix tooling is broad and deep. There&rsquo;s even a dedicated OS and functional programming language. Learn more with the <a href="https://nixos.wiki/wiki/Main_Page" target="_blank" rel="noopener">NixOS Wiki</a> or the <a href="https://nixos.org/nixos/nix-pills/" target="_blank" rel="noopener">Pills</a> Tutorial. The community IRC chat at <span class="inline-code">#nixos</span> on freenode is active and helpful.</p>
                                 <br><h2 class="section-title" id="nix-shell"><span class="inline-code">nix-shell</span></h2><br>
-                                <p>While working on Holochain, you will usually have an active <span class="inline-code">nix-shell</span> to run commands. All the extra dependencies and environment variables will be cleaned up automatically when you close the shell.</p>
-                                <p><span class="inline-code">nix-shell</span> will give you the latest releases every time you enter it. Nix is configured by <span class="inline-code">default.nix</span> files; these set all dependencies and variables that are added to your terminal.</p>
-                                <p>You can extend the master <span class="inline-code">default.nix</span> file or use it directly from <a href="https://holochain.love/" target="_blank" rel="noopener">https://holochain.love</a>. Opening a shell from holochain.love downloads updates automatically. The initial run will take some time to download and build. It gets much faster on subsequent runs.</p>
-                                <p><span class="inline-code">nix-shell</span> cleans up everything it added when you exit. You need to re-enter the shell each time you want to work.</p>
+                                <p>While working on Holochain, you will usually have an active <span class="inline-code">nix-shell</span> to run commands. All the extra dependencies and environment variables will be cleaned up automatically when you close the shell.</p>
+                                <p><span class="inline-code">nix-shell</span> will give you the latest releases every time you enter it. Nix is configured by <span class="inline-code">default.nix</span> files; these set all dependencies and variables that are added to your terminal.</p>
+                                <p>You can extend the master <span class="inline-code">default.nix</span> file or use it directly from <a href="https://holochain.love/" target="_blank" rel="noopener">https://holochain.love</a>. Opening a shell from holochain.love downloads updates automatically. The initial run will take some time to download and build. It gets much faster on subsequent runs.</p>
+                                <p><span class="inline-code">nix-shell</span> cleans up everything it added when you exit. You need to re-enter the shell each time you want to work.</p>
                                   <p><em>Note: The files are cached locally on your machine, so they will not be re-downloaded or rebuilt the next time you enter the shell.</em></p>
                                 <h4 id="Troubleshooting">Troubleshooting</h4>
-                                <p>By default, <span class="inline-code">nix-shell</span> only adds new things to your bash shell. Your existing setup could contain dependencies that override <span class="inline-code">nix-shell</span> and conflict with expectations.</p>
-                                <p>The following command tells <span class="inline-code">nix-shell</span> to attempt to isolate common conflicts.</p>
+                                <p>By default, <span class="inline-code">nix-shell</span> only adds new things to your bash shell. Your existing setup could contain dependencies that override <span class="inline-code">nix-shell</span> and conflict with expectations.</p>
+                                <p>The following command tells <span class="inline-code">nix-shell</span> to attempt to isolate common conflicts.</p>
                                 <p><code>nix-shell --pure</code></p>
                                   <p><em>Try this option first if you&rsquo;re seeing errors where others are not.</em></p>
                                 <p>The &ldquo;nix pod&rdquo; in Holochain core isolates more aggressively for debugging.</p>
-                                <br><h2 class="section-title" id="nix-env"><span class="inline-code">nix-env</span></h2><br>
-                                <p>You may choose to use nix-env to permanently install the Holochain tools into your regular development environment.</p>
-                                <p>This means that <span class="inline-code">hc</span> and <span class="inline-code">holochain</span> can be run at any time without needing to be in <span class="inline-code">nix-shell</span>. nix-env installations will override <span class="inline-code">nix-shell</span>. <span class="inline-code">nix-env</span> can also update or uninstall the tools it installs.</p>
                             </div>
 
                         </section>

--- a/start.html
+++ b/start.html
@@ -264,8 +264,8 @@
                                         <p>With nix-shell, you don’t need to worry about updating or uninstalling; when you enter the nix-shell, everything is the latest release and is then cleaned up when you exit.</p>
 
                                         <br><h5>Editor</h5>
-                                        <p>In most cases you can just run your editor as normal. However if you are using an integrated developer environment or IDE that needs to communicate with the Holochain dependencies then you should launch it from inside the nix-shell.</p> 
-                                        <p><em>To do this just open your edit while you are in the nix-shell like: <span class="button-hide"><code>[nix-shell:</code></span><code>vim my_file.rs</code></em></p>
+                                        <p>In most cases you can run your editor as normal. However, if you are using an integrated developer environment or IDE that needs to communicate with the Holochain dependencies then you should launch it from inside the nix-shell.</p> 
+                                        <p><em>To do this just open your editor while you are in the nix-shell like: <span class="button-hide"><code>[nix-shell:</code></span><code>vim my_file.rs</code></em></p>
                                 <br><br><h2 class="section-title">Build your first DNA</h2>
 
                                 <br><h3>Your first app</h3>

--- a/start.html
+++ b/start.html
@@ -44,7 +44,6 @@
     .copy-confirmation {
         margin-left: 10px;
     }
-
     .code-long .copy-to-clipboard { margin: 5px 0 0 0; display: inline-block; }
     .inline-code { padding: 2px 5px; background: #EEE; font-style: normal; font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New; }
     p em { margin: 7px 0; padding: 7px 0 7px 10px; color: #888; font-style: normal; border-left: 4px solid #DDD; display: block; }
@@ -234,58 +233,10 @@
                                     </div>
                                 </div>
 
-                                <br><h2 class="section-title">Install Rust</h2><br><br>
-
-                                <nav>
-                                    <div class="nav nav-tabs nav-fill" role="tablist">
-                                        <a class="nav-item nav-link active" data-toggle="tab" href="#rust-install-new"
-                                            role="tab" aria-controls="rust-install-new" aria-selected="true"><h5>New Rust installation</h5></a>
-                                        <a class="nav-item nav-link" data-toggle="tab" href="#rust-install-existing" role="tab"
-                                            aria-controls="rust-install-existing" aria-selected="false"><h5>Existing Rust installation</h5></a>
                                     </div>
-                                </nav>
+                                </div>
 
-                                <div class="tab-content py-3 px-3 px-sm-0" id="nav-tabContent">
-                                    <div class="tab-pane fade show active" id="rust-install-new" role="tabpanel"
-                                        aria-labelledby="rust-install-new">
-                                        
-                                        <p><em>Use this path if you are only installing Rust for Holochain development and don’t have an existing Rust installation.</em></p>
-
-                                        <p>Now that you have installed Nix, you can install all the prerequisites, including Rust and the Holochain tools, with this command:</p>
-
-                                        <p><code>nix-env -f https://holochain.love -iA holochain.holochain holochain.hc</code></p>
-
-                                        <p>Test this by running:</p>
-
-                                        <p><code>hc --version</code></p>
-
-                                        <p>and</p>
-
-                                        <p><code>holochain --version</code></p>
-                                        
-                                        <p>You should see something like:</p>
-
-                                        <p class="button-hide"><code>hc 0.0.29-alpha2</code></p>
-
-                                        <p class="button-hide"><code>holochain 0.0.29-alpha2</code></p>
-
-                                        <br><h5>Update/Uninstall</h5>
-
-                                        <p>To update the Holochain tools, simply run the install command again:</p>
-
-                                        <p><code>nix-env -f https://holochain.love -iA holochain.holochain holochain.hc</code></p>
-
-                                        <p>To uninstall, run:</p>
-
-                                        <p><code>nix-env -e holochain hc</code></p>
-
-                                    </div>
-
-                                    <div class="tab-pane fade" id="rust-install-existing" role="tabpanel"
-                                        aria-labelledby="rust-install-existing">
-                                        
-                                        <p><em>Use this path if you use Rust for other projects and want your existing setup to be left alone.</em></p>
-
+                                <h2 class="section-title">Install Holochain tools</h2><br>
                                         <p>Now that you have installed Nix, you can run a development shell that contains all the prerequisites, including the correct Rust version and the Holochain tools. This shell won’t interfere with your current Rust installation. Run this command:</p>
 
                                         <p><code>nix-shell https://holochain.love</code></p>
@@ -312,10 +263,10 @@
 
                                         <p>With nix-shell, you don’t need to worry about updating or uninstalling; when you enter the nix-shell, everything is the latest release and is then cleaned up when you exit.</p>
 
-                                    </div>
-                                </div>
-
-                                <br><h2 class="section-title">Build your first DNA</h2>
+                                        <br><h5>Editor</h5>
+                                        <p>In most cases you can just run your editor as normal. However if you are using an integrated developer envoronment or IDE that needs to communicate with the Holochain dependancies then you should launch it from inside the nix-shell.</p> 
+                                        <p><em>To do this just open your edit while you are in the nix-shell like: <span class="button-hide"><code>[nix-shell:</code></span><code>vim my_file.rs</code></em></p>
+                                <br><br><h2 class="section-title">Build your first DNA</h2>
 
                                 <br><h3>Your first app</h3>
 

--- a/start.html
+++ b/start.html
@@ -264,7 +264,7 @@
                                         <p>With nix-shell, you don’t need to worry about updating or uninstalling; when you enter the nix-shell, everything is the latest release and is then cleaned up when you exit.</p>
 
                                         <br><h5>Editor</h5>
-                                        <p>In most cases you can just run your editor as normal. However if you are using an integrated developer envoronment or IDE that needs to communicate with the Holochain dependancies then you should launch it from inside the nix-shell.</p> 
+                                        <p>In most cases you can just run your editor as normal. However if you are using an integrated developer environment or IDE that needs to communicate with the Holochain dependencies then you should launch it from inside the nix-shell.</p> 
                                         <p><em>To do this just open your edit while you are in the nix-shell like: <span class="button-hide"><code>[nix-shell:</code></span><code>vim my_file.rs</code></em></p>
                                 <br><br><h2 class="section-title">Build your first DNA</h2>
 


### PR DESCRIPTION
This removes `nix-env` from the quick start altogether. It was causing some confusion and @yegortimoshenko has pointed out some issue that could come from using it.
The only side effect of this is that anyone using an IDE will need to launch it from within nix-shell.
I have added a brief section about that but perhaps it should be more detailed and list how to launch all the common editors?