### PR TITLE
Add PyMdown Extras

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,3 +187,4 @@ markdown_extensions:
   - pymdownx.emoji
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.extra


### PR DESCRIPTION
To support definition lists, fancy punctuation, etc. The annoying thing about this extension is that it comes with a bunch of things, and you can't really tease them apart. May require fine-grained review of the built site.