### PR TITLE
turn on smarty extension; remove pymdownx.extra

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,8 +183,8 @@ markdown_extensions:
       guess_lang: false
   - toc:
       permalink: true
+  - smarty
   - pymdownx.tilde
   - pymdownx.emoji
   - pymdownx.details
   - pymdownx.superfences
-  - pymdownx.extra


### PR DESCRIPTION
I think I didn't understand the purpose of pymdownx.extra, and the [smartypants extension](https://python-markdown.github.io/extensions/smarty/) does what I want it to (em dashes from triple-hyphens).

(I have also dutifully pulled from `develop` first ;) )