### PR TITLE
Update hello_test.md

### DIFF
--- a/src/tutorials/coreconcepts/hello_test.md
+++ b/src/tutorials/coreconcepts/hello_test.md
@@ -96,7 +96,8 @@ const orchestrator = new Orchestrator({
 });
 ```
 ```diff
-const config = {
+-const conductorConfig = {
++const config = {
   instances: {
 -    myInstanceName: Config.dna(dnaPath, 'scaffold-test')
 +    cc_tuts: Config.dna(dnaPath, 'cc_tuts'),


### PR DESCRIPTION
The config variable created by the zomes generator is named `conductorConfig` while the config file used in the tutorial is just named `config`. The renaming wasn't indicated, so for clarity I would just add that one indication.