### PR TITLE
Update URL that points to conductor admin API doc

### DIFF
--- a/src/guide/conductor_admin.md
+++ b/src/guide/conductor_admin.md
@@ -4,6 +4,6 @@ It is possible to dynamically configure a Conductor via a JSON-RPC interface con
 
 To do this, first, recall that the `admin = true` [property needs to be set](./conductor_interfaces.md#admin-bool-optional) for the interface that should allow admin access. Second, it is helpful to review and understand the behaviours around the [`persistence_dir` property](./conductor_persistence_dir.md) for the Conductor.
 
-You can find details of the API for this functionality in the full [API reference material](https://developer.holochain.org/api/latest/holochain_conductor_api/interface/struct.ConductorApiBuilder.html#method.with_admin_dna_functions). Scroll to view the `with_admin_dna_functions` comment block and the `with_admin_ui_functions` comment block. Calling these functions works exactly the same way as the other [JSON-RPC API calls](./conductor_json_rpc_api.md).
+You can find details of the API for this functionality in the full [API reference material](https://github.com/holochain/holochain-rust/blob/1787f199b12118103cef4300dd4ebc423085d44b/crates/conductor_lib/src/interface.rs#L340). Scroll to view the `with_admin_dna_functions` comment block and the `with_admin_ui_functions` comment block. Calling these functions works exactly the same way as the other [JSON-RPC API calls](./conductor_json_rpc_api.md).
 
 As mentioned in [production Conductor](./production_conductor.md), there is a GUI in development that will cover all this functionality, so that it does not have to be done programmatically, but can be done by any user simply point and click.


### PR DESCRIPTION
I noticed that the HDK docs no longer have the docs from `ConductorApiBuilder.with_admin_dna_functions()`, which means that the URL in this document no longer works.

The long-term solution is to actually provide a nice documentation page/site for the conductor admin API. Before then, we've got three options:

* Link directly to the source, like I've done
* Make sure `ConductorApiBuilder` gets published to docs.rs
* Copy the documentation directly into this document

I feel like this needs a bigger discussion @dhtnetwork @freesig @Klayemore ; that's why I'm doing this as a PR rather than a hotfix. Is this hotfix the right choice _for right now_?