### PR TITLE
Remove more lines from default template

### DIFF
--- a/src/tutorials/coreconcepts/hello_holo.md
+++ b/src/tutorials/coreconcepts/hello_holo.md
@@ -149,15 +149,15 @@ You only need a few items for this tutorial, so go ahead and remove the others:
 extern crate hdk;
 extern crate hdk_proc_macros;
 extern crate serde;
-#[macro_use]
+- #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 - #[macro_use]
 extern crate holochain_json_derive;
-use hdk::{
+- use hdk::{
 -     entry_definition::ValidatingEntryType,
-    error::ZomeApiResult,
-};
+-    error::ZomeApiResult,
+- };
 - use hdk::holochain_core_types::{
 -     entry::Entry,
 -     dna::entry_types::Sharing,


### PR DESCRIPTION
Before I did this, I got the following compilation errors:

```
==> $ hc package
> cargo build --release --target-dir=target --target=wasm32-unknown-unknown
   Compiling hello v0.1.0 (/Users/harlan/code/holochain-learning/cc_tuts/zomes/hello/code)
error: unused `#[macro_use]` import
 --> src/lib.rs:5:1
  |
5 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`

error: unused import: `error::ZomeApiResult`
  --> src/lib.rs:11:5
   |
11 |     error::ZomeApiResult,
   |     ^^^^^^^^^^^^^^^^^^^^

error: aborting due to 2 previous errors

error: Could not compile `hello`.

To learn more, run the command again with --verbose.
Error: Couldn't traverse DNA in directory "/Users/harlan/code/holochain-learning/cc_tuts": command cargo build --release --target-dir=target --target=wasm32-unknown-unknown was not successful
```