### PR TITLE
hello me: fix for span variable renaming

### DIFF
--- a/src/tutorials/coreconcepts/hello_me.md
+++ b/src/tutorials/coreconcepts/hello_me.md
@@ -520,6 +520,9 @@ Pass in the element's ID so that the function can be reused:
 -  var span = document.getElementById('output');
 +  var el = document.getElementById(id);
   var output = JSON.parse(result);
+  ...
+-  span.textContent = ' ' + output.Ok;
++  el.textContent = ' ' + output.Ok; 
 ```
 It would also be nice to have some error checking.
 Add in a if statement that checks that `Ok` is not null:


### PR DESCRIPTION
Variable `span` is being renamed, but only in 1 out of 2 places it's being used. This commit fixes it.