### PR TITLE
Fix Firefox issue in tutorials: whitespace gets copied from address to address_in textbox

### DIFF
--- a/src/tutorials/coreconcepts/hello_me.md
+++ b/src/tutorials/coreconcepts/hello_me.md
@@ -616,7 +616,7 @@ function retrieve_person() {
 Get the value from the `address_in` text box:
 
 ```javascript
-  var address = document.getElementById('address_in').value;
+  var address = document.getElementById('address_in').value.trim();
 ```
 
 Wait for the connection; then make a zome call:

--- a/src/tutorials/coreconcepts/hello_world_gui.js
+++ b/src/tutorials/coreconcepts/hello_world_gui.js
@@ -31,7 +31,7 @@ function create_person() {
   });
 }
 function retrieve_person() {
-  var address = document.getElementById('address_in').value;
+  var address = document.getElementById('address_in').value.trim();
   holochain_connection.then(({callZome, close}) => {
     callZome('test-instance', 'hello', 'retrieve_person')({
       address: address,

--- a/src/tutorials/coreconcepts/simple_micro_blog.md
+++ b/src/tutorials/coreconcepts/simple_micro_blog.md
@@ -388,7 +388,7 @@ To retrieve the posts, update the `retrieve_person` function, and call `display_
 ```diff
 -function retrieve_person() {
 +function retrieve_posts() {
-  var address = document.getElementById('address_in').value;
+  var address = document.getElementById('address_in').value.trim();
   holochain_connection.then(({callZome, close}) => {
 -    callZome('test-instance', 'hello', 'retrieve_person')({
 +    callZome('test-instance', 'hello', 'retrieve_posts')({

--- a/src/tutorials/coreconcepts/simple_micro_blog_gui.js
+++ b/src/tutorials/coreconcepts/simple_micro_blog_gui.js
@@ -30,7 +30,7 @@ function create_person() {
   });
 }
 function retrieve_person() {
-  var address = document.getElementById('address_in').value;
+  var address = document.getElementById('address_in').value.trim();
   holochain_connection.then(({callZome, close}) => {
     callZome('test-instance', 'hello', 'retrieve_person')({
       address: address,


### PR DESCRIPTION
Trim whitespace when you get the contents of `address_in`. Fixes #163 .