### PR TITLE
Hotfix: Firefox issues with GUI-based tutorials

### DIFF
--- a/src/tutorials/coreconcepts/hello_gui.md
+++ b/src/tutorials/coreconcepts/hello_gui.md
@@ -62,15 +62,6 @@ Add this modern template:
 
     <title>Hello GUI</title>
     <meta name="description" content="GUI for a Holochain app" />
-  </head>
-
-  <body>
-```
-
-Inside the `<body>` tag, add a button that calls the hello function that we will add soon:
-
-```html
-  <button onclick="hello()" type="button">Say Hello</button>
 ```
 
 To make things a bit easier on the eyes, you can add the `water.css` stylesheet.
@@ -83,6 +74,19 @@ Add this water.css link inside the `<head>` tag:
       href="https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/dark.min.css"
     />
 ```
+\#S:HIDE
+
+```html
+  </head>
+
+  <body>
+```
+Inside the `<body>` tag, add a button that calls the hello function that we will add soon:
+
+```html
+  <button onclick="hello()" type="button">Say Hello</button>
+```
+
 
 \#S:EXTRA
 ```html

--- a/src/tutorials/coreconcepts/hello_gui.md
+++ b/src/tutorials/coreconcepts/hello_gui.md
@@ -23,7 +23,7 @@ You will need somewhere for all your GUI code to live. This will be a different 
 Create a folder for the GUI to live in:
 
 ```bash
-cd ~/holochain/core_concepts
+cd ~/holochain/coreconcepts
 mkdir gui
 cd gui
 ```

--- a/src/tutorials/coreconcepts/hello_test.md
+++ b/src/tutorials/coreconcepts/hello_test.md
@@ -182,7 +182,6 @@ For this test you simply want to get the Alice user to call the `hello_holo` zom
 
 Register a test scenario that checks `hello_holo()` returns the correct value:
 
-orchestrator.run();
 \#S:INCLUDE
 ```javascript
 orchestrator.registerScenario('Test hello holo', async (s, t) => {

--- a/src/tutorials/coreconcepts/hello_world.md
+++ b/src/tutorials/coreconcepts/hello_world.md
@@ -154,7 +154,6 @@ Start by running the conductor. Set the agent name to `Alice`.
 !!! note "Run in `nix-shell https://holochain.love`"
     ```
     hc package
-    hc run --networked sim2h --agent-name Alice --port 8888
     ```
 !!! check "Copy the DNA's hash with `hc hash`:"
     ```
@@ -162,7 +161,13 @@ Start by running the conductor. Set the agent name to `Alice`.
     ```
 > Your hash will be different but you need to update your `bundle.toml` file.
 
-If you're feeling lazy, I have provided a script in the [hello gui](../hello_gui) tutorial.
+If you're feeling lazy, I have provided a script in the [hello gui](../hello_gui/#run-the-bundle) tutorial.
+
+!!! note "Run in `nix-shell https://holochain.love`"
+    ```
+    hc run --networked sim2h --agent-name Alice --port 8888
+    ```
+
 
 #### Terminal three
 Start the second conductor with agent name set to `Bob`:


### PR DESCRIPTION
This fixes issues where copy/pasting the address in Firefox results in a silent error.