### PR TITLE
Footer menu rearrange

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -78,11 +78,6 @@
     <div class="md-footer-nav__inner md-grid">
       <nav class="site-footer-global-nav">
         <div class="site-footer-global-nav__section">
-          <h3><a href="https://holochain.org/">Holochain.org</a></h3>
-          <ul>
-          </ul>
-        </div>
-        <div class="site-footer-global-nav__section">
           <h3><a href="https://developer.holochain.org/">Developers</a></h3>
           <ul>
             <li><a href="https://developer.holochain.org/docs/">Get Started</a></li>
@@ -117,6 +112,14 @@
             <li><a href="https://blog.holochain.org/tag/community/">Community</a></li>
             <li><a href="https://blog.holochain.org/tag/foundation/">Foundation</a></li>
           </ul>
+          <div class="site-footer-global-nav__section">
+            <h3>Holochain &amp; Holo</h3>
+            <ul>
+              <li><a href="https://holochain.org/">Holochain.org</a></li>
+              <li><a href="https://holo.host/">Holo.host</a></li>
+              <li><a href="https://docs.google.com/document/d/1gDAvPz_NbANFRzZb1XO8MHoPUwR8fN2Jf7PHfQmBQ5Y/">Privacy Policy</a></li>
+            </ul>
+          </div>
         </div>
       </nav>
     </div>

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -112,14 +112,14 @@
             <li><a href="https://blog.holochain.org/tag/community/">Community</a></li>
             <li><a href="https://blog.holochain.org/tag/foundation/">Foundation</a></li>
           </ul>
-          <div class="site-footer-global-nav__section">
-            <h3>Holochain &amp; Holo</h3>
-            <ul>
-              <li><a href="https://holochain.org/">Holochain.org</a></li>
-              <li><a href="https://holo.host/">Holo.host</a></li>
-              <li><a href="https://docs.google.com/document/d/1gDAvPz_NbANFRzZb1XO8MHoPUwR8fN2Jf7PHfQmBQ5Y/">Privacy Policy</a></li>
-            </ul>
-          </div>
+        </div>
+        <div class="site-footer-global-nav__section">
+          <h3>Holochain &amp; Holo</h3>
+          <ul>
+            <li><a href="https://holochain.org/">Holochain.org</a></li>
+            <li><a href="https://holo.host/">Holo.host</a></li>
+            <li><a href="https://docs.google.com/document/d/1gDAvPz_NbANFRzZb1XO8MHoPUwR8fN2Jf7PHfQmBQ5Y/">Privacy Policy</a></li>
+          </ul>
         </div>
       </nav>
     </div>


### PR DESCRIPTION
1. Moved the Holochain.org column of the footer to the end.
2. Renamed it 'Holochain & Holo'.
3. Added the privacy policy (the point of this exercise).
4. Added links to holochain.org and holo.host.