### PR TITLE
Prep for RSM

### DIFF
--- a/build/assets/home/style.css
+++ b/build/assets/home/style.css
@@ -34,6 +34,9 @@ html { background: #f3f7fa; background-image: url(body-back.jpg); background-siz
 .holochain-rsm-guidance .content ul {
     font-size: 1.2rem;
     font-weight: 300;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-bottom: 1em;
 }
 
 .holochain-rsm-guidance .content b,

--- a/build/assets/home/style.css
+++ b/build/assets/home/style.css
@@ -1,6 +1,61 @@
 html, body { width: 100%; height: 100%; margin: 0; padding: 0; }
 html { background: #f3f7fa; background-image: url(body-back.jpg); background-size: cover; background-position: center; background-attachment: fixed; }
 
+/* RSM stuff -- get rid of this eventually */
+
+.rsm-banner {
+    position: relative;
+    width: 100%;
+    z-index: 1000;
+    margin-top: 50px;
+    background: #fa6;
+    padding: 1rem 0;
+}
+
+.rsm-banner p {
+    font-size: 1rem;
+    font-weight: normal;
+    padding-bottom: 0;
+    padding-right: 155px;
+}
+
+.rsm-banner-cta {
+    position: absolute;
+    right: 0;
+    font-size: 1rem;
+    top: -.75rem;
+}
+
+.rsm-banner-cta.rsm-banner-cta {
+    margin-top: 0 !important;
+}
+
+.holochain-rsm-guidance .content p,
+.holochain-rsm-guidance .content ul {
+    font-size: 1.2rem;
+    font-weight: 300;
+}
+
+.holochain-rsm-guidance .content b,
+.holochain-rsm-guidance .content strong {
+    font-weight: bold;
+}
+
+.holochain-rsm-guidance .intro {
+    padding: 1.5rem;
+    background: rgba(0,0,0,.1);
+    margin-bottom: 2rem;
+}
+
+.holochain-rsm-guidance .intro > p {
+    font-size: 1.5rem;
+}
+
+.holochain-rsm-guidance .intro > :last-child {
+    padding-bottom: 0;
+}
+
+
 /* General */
 
 .pad { padding: 0 5%; }

--- a/build/holochain-rsm-guidance.html
+++ b/build/holochain-rsm-guidance.html
@@ -1,0 +1,73 @@
+<html>
+    <head>
+        <title>Holochain RSM Guidance</title>
+        <link rel="shortcut icon" href="https://blog.holochain.org/favicon.png" type="image/png" />
+        <link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,600,700,800" rel="stylesheet">
+        <link rel="stylesheet" type="text/css" href="assets/home/style.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+
+    <body class="holochain-rsm-guidance">
+        <div class="hero" style="height:auto">
+            <div class="h-banner" style="position:relative">
+                <div class="h-pad">
+                    <div class="h-wrap">
+                        <ul class="h-nav">
+                            <li class="tab-home"><a href="https://holochain.org"><img src="https://forum.holochain.org/uploads/default/original/1X/79f6577e3c8102e1f0caf8d2f43d4fcf472a3e34.png"> <span class="h-hide">Holochain.org</span></a></li>
+                            <li class="tab-developers"><a href="https://developer.holochain.org/">Developers</a></li>
+                            <li class="tab-forum"><a href="https://forum.holochain.org/">Forum</a></li>
+                            <li class="tab-blog"><a href="https://blog.holochain.org/">Blog</a></li>
+                            <li class="tab-events"><a href="https://holochain.org/events.html">Events</a></li>
+                        </ul>
+                        <ul class="h-icons">
+                            <li><a href="https://blog.holochain.org/#subscribe" target="_blank">Subscribe</a></li>
+                            <li><a href="https://github.com/holochain/holochain-rust/" target="_blank" title="GitHub">
+                                <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+                            </a></li>
+                            <li><a href="https://twitter.com/holochain" target="_blank" title="Twitter">
+                                <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M23.954 4.569c-.885.389-1.83.654-2.825.775 1.014-.611 1.794-1.574 2.163-2.723-.951.555-2.005.959-3.127 1.184-.896-.959-2.173-1.559-3.591-1.559-2.717 0-4.92 2.203-4.92 4.917 0 .39.045.765.127 1.124C7.691 8.094 4.066 6.13 1.64 3.161c-.427.722-.666 1.561-.666 2.475 0 1.71.87 3.213 2.188 4.096-.807-.026-1.566-.248-2.228-.616v.061c0 2.385 1.693 4.374 3.946 4.827-.413.111-.849.171-1.296.171-.314 0-.615-.03-.916-.086.631 1.953 2.445 3.377 4.604 3.417-1.68 1.319-3.809 2.105-6.102 2.105-.39 0-.779-.023-1.17-.067 2.189 1.394 4.768 2.209 7.557 2.209 9.054 0 13.999-7.496 13.999-13.986 0-.209 0-.42-.015-.63.961-.689 1.8-1.56 2.46-2.548l-.047-.02z"/></svg>
+                            </a></li>
+                            <li><a href="https://www.facebook.com/holochain.design/" target="_blank" title="Facebook">
+                                <svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M23.9981 11.9991C23.9981 5.37216 18.626 0 11.9991 0C5.37216 0 0 5.37216 0 11.9991C0 17.9882 4.38789 22.9522 10.1242 23.8524V15.4676H7.07758V11.9991H10.1242V9.35553C10.1242 6.34826 11.9156 4.68714 14.6564 4.68714C15.9692 4.68714 17.3424 4.92149 17.3424 4.92149V7.87439H15.8294C14.3388 7.87439 13.8739 8.79933 13.8739 9.74824V11.9991H17.2018L16.6698 15.4676H13.8739V23.8524C19.6103 22.9522 23.9981 17.9882 23.9981 11.9991Z"/></svg>
+                            </a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <main class="content" style="padding-top: 2rem">
+            <div class="h-wrap" style="max-width:960px">
+                <h1>Holochain RSM Guidance</h1>
+
+                <div class="intro">
+                    <p>On 15 September 2020 we <a href="https://medium.com/h-o-l-o/a-big-leap-forward-for-holochain-holo-2efaaa54ed08">unveiled a new Holochain</a>, which we’re currently calling <a href="https://github.com/holochain/holochain">Holochain RSM</a> (Refactored State Model). This documentation site is for the <b>previous version</b>, now called <a href="https://github.com/holochain/holochain-rust">Holochain Redux</a>, and will be <b>deprecated</b> when RSM is released. The documentation will be gradually rewritten for RSM; in the meantime, we’ve indicated places where the information in this documentation will become obsolete.</p>
+                    <p>This guidance page supports both existing and new developers in learning more.</p>
+                </div>
+
+                <h3>New developers</h3>
+
+                <p>Holochain RSM hasn’t been officially released, but it will be soon. We encourage you to wait until then. In the meantime, read the intro content on this website—it’s still relevant (and mostly accurate). Start with <a href="/docs/what-is-holochain/">What is Holochain</a> and <a href="/docs/why-holochain/">Why Holochain</a>, then read the <a href="/docs/concepts/">Core Concepts</a> while you keep the <a href="/docs/glossary/">Glossary</a> nearby.</p>
+
+                <h3>Existing developers</h3>
+
+                <p>If you want to get yourself prepared for porting your Holochain app to RSM, here are some provisional resources:</p>
+
+                <ul>
+                    <li><a href="https://blog.holochain.org/announcing-and-unpacking-the-new-holochain/">Announcing and Unpacking the New Holochain</a></li>
+                    <li><a href="https://github.com/holochain/holochain">Holochain RSM GitHub repository</a></li>
+                    <li><a href="https://github.com/holochain/holochain/blob/develop/README.md#development-environment">Instructions on getting started with Holochain RSM</a></li>
+                    <li><a href="https://github.com/holochain/holochain/blob/develop/crates/hdk/README.md">README for the new HDK</a></li>
+                    <li><a href="https://github.com/holochain/holochain-serialization/tree/develop/crates/holochain_serialized_bytes">Information and guidelines on serialising your data</a>, including entries and function parameters/returns</li>
+                    <li><a href="https://github.com/holochain/holochain/blob/develop/docs/build_tutorial.md">Building your DNA</a></li>
+                    <li><a href="https://github.com/holochain/holochain/tree/develop/crates/dna_util">`dna_util` command reference</a></li>
+                    <li>The <a href="https://github.com/holochain/holochain/tree/develop/crates/test_utils/wasm/wasm_workspace">test suite</a>, currently the best place for examples of how to use the API and HDK</li>
+                    <li><a href="https://holo.hackmd.io/iFrWEJ0TREqO6iF5iuDcSg?view">Holochain formal specification</a>, a ‘living document’ from the core devs (some details may be out of date)</li>
+                </ul>
+
+                <p>As always, you can also <a href="https://forum.holochain.org/c/technical/RSM/126">head over to the Holochain Forum</a> and talk with our community of developers and team members.</p>
+
+            </div>
+        </main>
+    </body>
+</html>

--- a/build/index.html
+++ b/build/index.html
@@ -61,6 +61,17 @@ heap.load("1266209723");
 	    </div>
 	</div>
 
+	<!------ RSM banner | START ------>
+
+	<div class="rsm-banner">
+		<div class="h-wrap">
+			<p><strong>NOTICE!</strong> This documentation site will be deprecated soon; we're currently writing documentation for the new Holochain RSM.</p>
+			<a class="rsm-banner-cta button" href="holochain-rsm-guidance.html">Read more</a>
+		</div>
+	</div>
+
+	<!------ RSM banner | END ------>
+
 	<div class="content">
 		<div class="pad">
 			<h1>Build Resilient,<br>

--- a/src/custom/style.css
+++ b/src/custom/style.css
@@ -1,3 +1,33 @@
+/* RSM stuff -- get rid of this eventually */
+
+.rsm-banner {
+    position: relative;
+    width: 100%;
+    z-index: 1000;
+    margin-top: 50px;
+    background: #fa6;
+    padding: 1rem 0;
+}
+
+.rsm-banner p {
+    font-size: 1rem;
+    font-weight: normal;
+    padding-bottom: 0;
+    padding-right: 155px;
+}
+
+.rsm-banner-cta {
+    position: absolute;
+    right: 0;
+    font-size: 1rem;
+    top: -.75rem;
+}
+
+.rsm-banner-cta.rsm-banner-cta {
+    margin-top: 0 !important;
+}
+
+
 /* Font */
 
 .md-typeset h1, .md-typeset h2 { font-weight: 700; color: rgba(0,0,0,.87);  letter-spacing: -.5px; }

--- a/src/custom/style.css
+++ b/src/custom/style.css
@@ -4,29 +4,28 @@
     position: relative;
     width: 100%;
     z-index: 1000;
-    margin-top: 50px;
     background: #fa6;
     padding: 1rem 0;
 }
 
 .rsm-banner p {
-    font-size: 1rem;
+    font-size: .8rem;
     font-weight: normal;
-    padding-bottom: 0;
     padding-right: 155px;
+    margin: 0;
 }
 
 .rsm-banner-cta {
     position: absolute;
     right: 0;
-    font-size: 1rem;
-    top: -.75rem;
+    font-size: .8rem;
+    top: -.5rem;
+	background: #00FFCE;
+	color: #000;
+	padding: 2px 12px;
+	line-height: 2;
+	font-weight: bold;
 }
-
-.rsm-banner-cta.rsm-banner-cta {
-    margin-top: 0 !important;
-}
-
 
 /* Font */
 

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -93,3 +93,10 @@ if (document.location.pathname.indexOf("/docs/concepts/") == 0) {
 }
 
 </script>
+
+<div class="rsm-banner">
+  <div class="h-wrap">
+    <p><strong>NOTICE!</strong> This documentation site will be deprecated soon; we're currently writing documentation for the new Holochain RSM.</p>
+    <a class="rsm-banner-cta button" href="holochain-rsm-guidance.html">Read more</a>
+  </div>
+</div>


### PR DESCRIPTION
This puts up an announcement and a resource page re: the pending retirement of Redux (along with the entire documentation site) and the introduction of RSM. When RSM is released we'll move the Redux documentation to `docs-old/` and put the RSM documentation at the root of the site. The home page will be removed, letting the holochain.org site do the marketing stuff. Or sometihng like that.