### PR TITLE
Publish dev docs v0.4.5

### DIFF
--- a/src/changelog.md
+++ b/src/changelog.md
@@ -7,6 +7,10 @@ The documentation aims to stay up to date with the latest release, so there are 
 
 We want this to be as easy as possible, so we’ve committed to documenting not just the breaking changes, but the fixes as well.
 
+## 0.4.4 → 0.4.5
+
+Removed the landing page and some markety content; moved all `/docs` URLs to the root fo the site; set up better redirects to the Holochain Redux developer documentation
+
 ## 0.4.3 → 0.4.4
 
 Changed install URL to nightly.holochain.love; added some pro tips for developers who want to keep their preferred shell; removed RSM notice banner

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -48,7 +48,7 @@
             {{ config.site_name }}
           {% else %}
             <span class="md-header-nav__topic">
-              {{ config.site_name }} <span class="version"><a href="/docs/changelog" title="Changelog">v0.4.4</a></span>
+              {{ config.site_name }} <span class="version"><a href="/docs/changelog" title="Changelog">v0.4.5</a></span>
             </span>
             <span class="md-header-nav__topic">
               {% if page and page.meta and page.meta.title %}


### PR DESCRIPTION
Changelog:

* removed landing page
* removed other markety pages
    * Why Holochain
    * Who is Holochain for
* Moved all docs from `/docs` to root of site
* Redirects for core concepts (should've done these ages ago)
* Set up better redirects for Redux documentation
    * Guidebook
    * Tutorials
    * Build your first app