### PR TITLE
Simplified installation instructions

### DIFF
--- a/src/install-advanced.md
+++ b/src/install-advanced.md
@@ -48,7 +48,7 @@ Any time you want to get the latest version of the dev tools, just `exit` the sh
 
 ## Uninstalling
 
-You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. If you want to free up some space, run these commands:
+You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. On macOS it adds users and a user group too. If you want to free up some space, run these commands:
 
 ```bash
 rm -rf ~/.holonix
@@ -61,6 +61,7 @@ If you want to uninstall Nix as well, run these commands (you might need root pr
 rm -rf /nix
 rm ~/.nix-profile
 ```
+[Detailed uninstallation instructions for macOS](https://gist.github.com/chriselsner/3ebe962a4c4bd1f14d39897fc5619732#uninstalling-nix)
 
 ## Using a specific version of the development tools
 

--- a/src/install-advanced.md
+++ b/src/install-advanced.md
@@ -51,7 +51,6 @@ Any time you want to get the latest version of the dev tools, just `exit` the sh
 You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. On macOS it adds users and a user group too. If you want to free up some space, run these commands:
 
 ```bash
-rm -rf ~/.holonix
 nix-collect-garbage -d
 ```
 

--- a/src/install.md
+++ b/src/install.md
@@ -199,6 +199,7 @@ in nixpkgs.mkShell {
   ];
 }
 ```
+
 #### Upgrading Holochain in default.nix
 
 All you need to do to upgrade the version of Holochain in your project is run
@@ -206,6 +207,7 @@ All you need to do to upgrade the version of Holochain in your project is run
 ```bash
 nix-shell --run "niv update"
 ```
+
 ### Advanced usage
 
 Read through our [advanced installation guide](../install-advanced/) for tips and tricks on making your development environment easier to work with, or what to do in case you need to work offline.

--- a/src/install.md
+++ b/src/install.md
@@ -194,15 +194,20 @@ in nixpkgs.mkShell {
   inputsFrom = [ holonix.main ];
   packages = with nixpkgs; [
     niv
-
     # any additional packages needed for this project, e. g. Nodejs
   ];
 }
 ```
 
-#### Upgrading Holochain in default.nix
+#### Upgrading Holochain referenced in default.nix
 
-All you need to do to upgrade the version of Holochain in your project is run
+If you want to be in a position to automatically upgrade your project to the most recent version of Holochain, you need to initalize a tool called `niv` after setting up your project.
+
+```bash
+nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.11.tar.gz -p niv --run "niv init && niv drop nixpkgs && niv drop niv && niv add -b main holochain/holonix"
+```
+
+`niv` serves as an easy way to manage dependency. Once it's initalized, all you need to do to upgrade Holochain to the most recent version in your project is run
 
 ```bash
 nix-shell --run "niv update"

--- a/src/install.md
+++ b/src/install.md
@@ -188,7 +188,7 @@ If you want to automatically upgrade your project to the most recent version of 
 nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.11.tar.gz -p niv --run "niv init && niv drop nixpkgs && niv drop niv && niv add -b main holochain/holonix"
 ```
 
-Executing this command creates a new folder named `nix` with 2 files that `niv` needs to retrieve the revision of the latest Holochain version.
+Executing this command creates a new folder named `nix` with 2 files that `niv` needs to retrieve the revision of the latest Holonix version.
 
 Next you need to add a `default.nix` file as a Nix configuration of your development environment, including Holochain as a dependency.
 This is a minimal `default.nix` file with a specific version of Holochain:
@@ -211,9 +211,25 @@ in nixpkgs.mkShell {
 
 Now you can enter the Nix shell with your development environment by running the command `nix-shell`. Once it's finished you have the Holochain commands at your disposal.
 
-#### Upgrading to the latest version of Holochain
+> niv initializes and updates to the latest revision of the Holonix repository. As every revision contains configurations for several previous versions of Holochain, you need to explicitly define the exact version of Holochain you want to use. In other words, niv does not set a Holochain version; it's defined in `default.nix`.
 
-When the time has come to upgrade your hApp to the latest version of Holochain, you first have to set the version id in `default.nix`. E. g.
+#### Upgrading the Holochain version
+
+When the time has come to upgrade your hApp to a newer version of Holochain, there are 3 steps to follow:
+
+1. Update the Holonix revision using `niv`:
+
+```bash
+nix-shell --run "niv update"
+```
+
+2. Run `hn-versions` to see which versions of Holochain are available:
+
+```bash
+nix-shell --run "hn-versions"
+```
+
+3. Set the `holochainVersionid` accordingly:
 
 ```nix
 ...
@@ -223,13 +239,9 @@ When the time has come to upgrade your hApp to the latest version of Holochain, 
 ...
 ```
 
-Then all you have to do is execute
+Now you can `exit` the Nix shell and re-enter it via `nix-shell`. The updated version of Holochain will be downloaded and made available in the resulting Nix shell.
 
-```bash
-nix-shell --run "niv update"
-```
-
-After the update completes, you can exit the Nix shell by running `exit` and re-enter it via `nix-shell`. The updated version of Holochain will be downloaded and made available in the result Nix shell.
+> Keep in mind that the Holonix repo includes Nix configurations for the last ~ 5 versions of Holochain. That means that if you keep updating its revision using `niv`, you will have to augment the Holochain version id in `default.nix` sooner or later too.
 
 ### Advanced usage
 

--- a/src/install.md
+++ b/src/install.md
@@ -171,17 +171,26 @@ It will always keep you up to date with the newest stable version of Holochain a
 
 Holochain is currently in rapid development, which means newer versions introduce new features and breaking changes. This means that it's likely that the version that you get with `nix-shell https://holochain.love` won't always work with existing hApp repositories or even breaks a hApp you were working on.
 
-To solve this, repositories of hApp projects can use Nix to pin the appropriate Holochain version to work well for that hApp. To do this, the project needs to have a `default.nix` file in the root folder of the repository. You must not be inside the `nix-shell` provided by https://holochain.love. Instead, simply navigate to the folder with the `default.nix` file and run:
+To solve this, hApp projects can use Nix to pin a compatible Holochain version. The project needs to have a `default.nix` file in the root folder of the repository. Don't run this from inside the `nix-shell` provided by https://holochain.love. Instead, simply navigate to the project's root folder where the `default.nix` file needs to be and run:
 
 ```bash
 nix-shell
 ```
 
-This command looks for a `default.nix` file in the current folder and will create the environment as specified.
+This command looks for a `default.nix` file in the current folder and will create the specified environment.
 
-#### Example default.nix file
+#### Initialize a project for easy Holochain version upgrades
 
-This is a minimal `default.nix` file to use a specific version of Holochain:
+If you want to automatically upgrade your project to the most recent version of Holochain, you need to initalize a tool called `niv` for your project.
+
+```bash
+nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.11.tar.gz -p niv --run "niv init && niv drop nixpkgs && niv drop niv && niv add -b main holochain/holonix"
+```
+
+Executing this command creates a new folder named `nix` with 2 files that `niv` needs to retrieve the revision of the latest Holochain version.
+
+Next you need to add a `default.nix` file as a Nix configuration of your development environment, including Holochain as a dependency.
+This is a minimal `default.nix` file with a specific version of Holochain:
 
 ```nix
 let
@@ -199,19 +208,27 @@ in nixpkgs.mkShell {
 }
 ```
 
-#### Upgrading Holochain referenced in default.nix
+Now you can enter the Nix shell with your development environment by running the command `nix-shell`. Once it's finished you have the Holochain commands at your disposal.
 
-If you want to be in a position to automatically upgrade your project to the most recent version of Holochain, you need to initalize a tool called `niv` after setting up your project.
+#### Upgrading to the latest version of Holochain
 
-```bash
-nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.11.tar.gz -p niv --run "niv init && niv drop nixpkgs && niv drop niv && niv add -b main holochain/holonix"
+When the time has come to upgrade your hApp to the latest version of Holochain, you first have to set the version id in `default.nix`. E. g.
+
+```nix
+...
+  holonix = import (holonixPath) {
+    holochainVersionId = "v0_0_127";
+  };
+...
 ```
 
-`niv` serves as an easy way to manage dependency. Once it's initalized, all you need to do to upgrade Holochain to the most recent version in your project is run
+Then all you have to do is execute
 
 ```bash
 nix-shell --run "niv update"
 ```
+
+After the update completes, you can exit the Nix shell by running `exit` and re-enter it via `nix-shell`. The updated version of Holochain will be downloaded and made available in the result Nix shell.
 
 ### Advanced usage
 

--- a/src/install.md
+++ b/src/install.md
@@ -60,14 +60,6 @@ sh <(curl -L https://nixos.org/nix/install)
 
 We use the Nix toolkit to manage the installation of our dev tools, so you can get to work without fighting compiler and package compatibility issues. Install the Nix package manager with this command:
 
-#### macOS 10.15 Catalina and later
-
-```bash
-sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
-```
-
-#### macOS 10.14 Mojave and earlier
-
 ```bash
 sh <(curl -L https://nixos.org/nix/install)
 ```

--- a/src/install.md
+++ b/src/install.md
@@ -239,7 +239,7 @@ nix-shell --run "hn-versions"
 ...
 ```
 
-Now you can `exit` the Nix shell and re-enter it via `nix-shell`. The updated version of Holochain will be downloaded and made available in the resulting Nix shell.
+The next time you enter your hApp development environment using `nix-shell`, the updated version of Holochain will be downloaded and made available in the resulting Nix shell.
 
 > Keep in mind that the Holonix repo includes Nix configurations for the last ~ 5 versions of Holochain. That means that if you keep updating its revision using `niv`, you will have to augment the Holochain version id in `default.nix` sooner or later too.
 

--- a/src/install.md
+++ b/src/install.md
@@ -229,7 +229,7 @@ nix-shell --run "niv update"
 nix-shell --run "hn-versions"
 ```
 
-3. Set the `holochainVersionid` accordingly:
+3. Set the `holochainVersionId` accordingly:
 
 ```nix
 ...

--- a/src/install.md
+++ b/src/install.md
@@ -124,12 +124,12 @@ If you don't use Cachix, nix-shells will take around 20-30 min for every version
 Run the following commands to set up the cache:
 
 ```bash
-nix-env -iA cachix -f https://cachix.org/api/v1/install
-cachix use holochain-ci
+nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-21.11.tar.gz -p cachix --run "cachix use holochain-ci"
 ```
 
 ## Using the Holochain dev tools
-You can use the Holochain dev tools in two ways, either by creating a nix file which specifies the Holochain version or by using a link that points to a current version. Usually Holochain projects define a specific Holochain version that they're running on and compatible with, just like Rust crates or NPM packages are included in a project with a particular version. If you  want play around with Holochain and the dev tools, you can use the link with an ad-hoc nix-shell.
+
+You can use the Holochain dev tools in two ways, either by [creating a nix file](#using-holochain-with-a-pinned-holochain-version) which specifies the Holochain version or by using a URL that points to the most recent release. Usually Holochain projects define a specific Holochain version that they're running on and compatible with, just like Rust crates or NPM packages are included in a project with a particular version. If you  want play around with Holochain and the dev tools, you can use the URL with an ad-hoc nix-shell.
 ### Ad-hoc nix-shells with a current version of Holochain dev tools
 
 Use this one-liner to load Holonix:
@@ -166,6 +166,7 @@ nix-shell https://holochain.love
 ```
 
 It will always keep you up to date with the newest stable version of Holochain and the dev tools.
+
 ### Using Holochain with a pinned Holochain version
 
 Holochain is currently in rapid development, which means newer versions introduce new features and breaking changes. This means that it's likely that the version that you get with `nix-shell https://holochain.love` won't always work with existing hApp repositories or even breaks a hApp you were working on.
@@ -175,10 +176,13 @@ To solve this, repositories of hApp projects can use Nix to pin the appropriate 
 ```bash
 nix-shell
 ```
+
 This command looks for a `default.nix` file in the current folder and will create the environment as specified.
 
 #### Example default.nix file
+
 This is a minimal `default.nix` file to use a specific version of Holochain:
+
 ```nix
 let
   holonixPath = (import ./nix/sources.nix).holonix; # points to the current state of the Holochain repository
@@ -189,18 +193,23 @@ let
 in nixpkgs.mkShell {
   inputsFrom = [ holonix.main ];
   packages = with nixpkgs; [
+    niv
+
     # any additional packages needed for this project, e. g. Nodejs
   ];
 }
 ```
 #### Upgrading Holochain in default.nix
+
 All you need to do to upgrade the version of Holochain in your project is run
+
 ```bash
-nix-shell -p niv --run "niv update ..."
+nix-shell --run "niv update"
 ```
 ### Advanced usage
 
 Read through our [advanced installation guide](../install-advanced/) for tips and tricks on making your development environment easier to work with, or what to do in case you need to work offline.
+
 ## Next Steps
 
 1. Read through the [Holochain Core Concepts](../concepts/).


### PR DESCRIPTION
I've simplified the installation instructions and broken down the section on using Holochain dev tools into using ad-hoc shells and creating `default.nix` files. @pdaoust We're working towards a simple process of upgrading the pinned Holochain version.

@steveeJ Please review. I need your help with the `niv` command.
Looking through our conversations I saw another form of `default.nix`:
```nix
let
  holonixPath = builtins.fetchTarball "https://github.com/holochain/holonix/archive/$(git ls-remote https://github.com/holochain/holonix main | grep -oP '[0-9a-z]{40}').tar.gz";
  holonix = import (holonixPath) {
    holochainVersionId = "v0_0_120";
  };
  nixpkgs = holonix.pkgs;
in nixpkgs.mkShell {
  inputsFrom = [ holonix.shell ];
  packages = [
    # additional packages go here
  ];
}
```
Would that be even easier than running `niv`, because one only needs to increase the version number?