### PR TITLE
Feat: Add section on HC introspection commands & add page to scaffold and run hApps

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - Introduction: index.md
     - What is Holochain?: what-is-holochain.md
     - Install Holochain: install.md
+    - hApp Setup: happ-setup.md
     - Get Involved: get-involved.md
     - Glossary: glossary.md
     - Advanced Installation Tips: install-advanced.md

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -9,7 +9,7 @@ We want this to be as easy as possible, so we’ve committed to documenting not 
 
 ## 0.5.5 → 0.5.6
 
-Add section for `hn-*` commands.
+Add new page on how to scaffold new hApps and how to run hApp binaries.
 
 ## 0.5.4 → 0.5.5
 

--- a/src/changelog.md
+++ b/src/changelog.md
@@ -7,6 +7,10 @@ The documentation aims to stay up to date with the latest release, so there are 
 
 We want this to be as easy as possible, so we’ve committed to documenting not just the breaking changes, but the fixes as well.
 
+## 0.5.5 → 0.5.6
+
+Add section for `hn-*` commands.
+
 ## 0.5.4 → 0.5.5
 
 Simplify Nix & Holochain installation instructions.

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -100,7 +100,7 @@ When you're done setting up the hApp in this graphical way, all files will be pr
 
 ## Running a deployed hApp
 
-At some stage in the app development you'll want to deploy your hApp for others to use it. If you've created the hApp with the scaffolding tools, all you need to do to package is is run
+At some stage in the app development you'll want to deploy your hApp for others to use it. If you've created the hApp with the scaffolding tools, all you need to do to package is run
 
 ```bash
 npm run package

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -1,0 +1,109 @@
+---
+hide:
+  - toc
+---
+
+## Scaffolding a new hApp
+
+Commands that serve to set up a new Holochain app (hApp) are at your fingertips. There are two ways in which you can create a new hApp: generate an empty project or use a GUI to describe your app's structure and then generate it. **All of the following commands need to be run from a Holochain nix-shell.**
+
+### Create an empty project
+
+The command to set up a new empty project is
+
+```bash
+hn-init
+```
+
+It will create a new folder named "my-app" in the current directory. Inside that new folder there's a number of files and folders:
+
+- initialized git repository
+- initialized npm package
+- default.nix configuration for the Holochain nix-shell
+- a DNA with one Zome
+- configuration files to bundle DNA, hApp and Web hApp (UI + hApp)
+- Tryorama setup for e2e tests of the DNA
+- a Vuejs skeleton frontend hooked up to the DNA
+- npm scripts for developing, testing, building and packaging the hApp
+
+> The generated file structure is the recommended layout for hApps.
+
+```bash
+├── Cargo.toml
+├── default.nix
+├── dnas
+│   └── dna-1
+│       ├── workdir
+│       │   └── dna.yaml
+│       └── zomes
+│           └── zome-1
+│               ├── Cargo.toml
+│               └── src
+│                   ├── entry-def-1
+│                   │   ├── entry.rs
+│                   │   ├── handlers.rs
+│                   │   └── mod.rs
+│                   └── lib.rs
+├── package.json
+├── README.md
+├── tests
+│   ├── package.json
+│   ├── src
+│   │   ├── dna-1
+│   │   │   └── zome-1
+│   │   │       └── entry-def-1.ts
+│   │   ├── index.ts
+│   │   └── utils.ts
+│   └── tsconfig.json
+├── ui
+│   ├── index.html
+│   ├── package.json
+│   ├── public
+│   │   └── favicon.ico
+│   ├── README.md
+│   ├── src
+│   │   ├── App.vue
+│   │   ├── assets
+│   │   │   └── logo.png
+│   │   ├── components
+│   │   │   └── HelloWorld.vue
+│   │   ├── env.d.ts
+│   │   ├── main.ts
+│   │   ├── services
+│   │   │   └── appWebsocket.ts
+│   │   └── types.ts
+│   │       └── dna-1
+│   │           └── zome-1.ts
+│   ├── tsconfig.json
+│   └── vite.config.ts
+└── workdir
+    ├── happ.yaml
+    └── web-happ.yaml
+
+20 directories, 30 files
+```
+
+You can enter the Holochain nix-shell and immediately start developing your hApp.
+
+### Create a new hApp using the GUI
+
+If you already know the data structure of your hApp or prefer a visual way of defining the hApp's entries, you can create the new hApp using a GUI.
+
+```bash
+holochain-create
+```
+
+The resulting hApp is laid out as printed above. A web app is executed and opens in the default web browser. It provides controls to add DNAs and Zomes, and to add and configure
+field name and types of your hApp's entry definitions. Further you can choose between different templates for the hApp's UI.
+
+When you're done setting up the hApp in this graphical way, all files will be produced in the folder "my-app".
+
+## Running a deployed hApp
+
+At some stage in the app development you'll want to deploy your hApp for others to use it. If you've created the hApp with the scaffolding tools, all you need to do to package is is run
+
+```bash
+npm run package
+```
+
+The app bundle ending in `.webhapp` will be available in the project root's `workdir` folder. Now you can deploy it to a place where users can download it. In order to install and run the hApp, there's a GUI for administrating apps on a computer. It's called the Holochain Launcher. To download and use it, refer to https://github.com/holochain/launcher.

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -31,7 +31,7 @@ It will create a new folder named "my-app" in the current directory. Inside that
 - a Vuejs skeleton frontend hooked up to the DNA
 - npm scripts for developing, testing, building and packaging the hApp
 
-> The generated file structure is the recommended layout for hApps.
+*The generated file structure is the recommended layout for hApps.*
 
 ```bash
 ├── Cargo.toml

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -90,6 +90,8 @@ It will create a new folder named "my-app" in the current directory. Inside that
 
 You can enter the Holochain nix-shell and immediately start developing your hApp.
 
+> Internally, the `hn-init` command is an alias for a sub command of the scaffolding tool: `holochain-create init`.
+
 ### Create a new hApp using the GUI
 
 If you already know the data structure of your hApp or prefer a visual way of defining the hApp's entries, you can create the new hApp using a GUI.

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -5,7 +5,12 @@ hide:
 
 ## Scaffolding a new hApp
 
-Commands that serve to set up a new Holochain app (hApp) are at your fingertips. There are two ways in which you can create a new hApp: generate an empty project or use a GUI to describe your app's structure and then generate it. **All of the following commands need to be run from a Holochain nix-shell.**
+Commands to set up a new Holochain app (hApp) are at your fingertips. There are two ways in which you can create one:
+
+1. generate an empty project or
+2. use a GUI to describe your app's structure and then generate it.
+
+**All of the following commands need to be run from a Holochain nix-shell.** [Steps to set up such a nix-shell](../install/#using-holochain-with-a-pinned-holochain-version/).
 
 ### Create an empty project
 

--- a/src/happ-setup.md
+++ b/src/happ-setup.md
@@ -10,7 +10,7 @@ Commands to set up a new Holochain app (hApp) are at your fingertips. There are 
 1. generate an empty project or
 2. use a GUI to describe your app's structure and then generate it.
 
-**All of the following commands need to be run from a Holochain nix-shell.** [Steps to set up such a nix-shell](../install/#using-holochain-with-a-pinned-holochain-version/).
+**All of the following commands need to be run from a Holochain nix-shell.** [Steps to set up such a nix-shell](../install/#using-holochain-with-a-pinned-holochain-version).
 
 ### Create an empty project
 

--- a/src/install-advanced.md
+++ b/src/install-advanced.md
@@ -42,10 +42,6 @@ cd my_project
 vim my_file.rs
 ```
 
-## Upgrading
-
-Any time you want to get the latest version of the dev tools, just `exit` the shell and enter it again; if there are any updates it'll automatically download them.
-
 ## Uninstalling
 
 You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. On macOS it adds users and a user group too. If you want to free up some space, run these commands:

--- a/src/install.md
+++ b/src/install.md
@@ -245,7 +245,7 @@ The next time you enter your hApp development environment using `nix-shell`, the
 
 ### Holochain inspection commands
 
-Built into Holochain are a few commands that give insight about versions of Holochain components.
+Built into Holochain and holonix are a few commands that give insight about versions of Holochain components.
 
 ```bash
  hn-introspect

--- a/src/install.md
+++ b/src/install.md
@@ -298,7 +298,7 @@ Read through our [advanced installation guide](../install-advanced/) for tips an
 
 1. Read through the [Holochain Core Concepts](../concepts/).
 2. Try [building and running a sample hApp](https://github.com/holochain/happ-build-tutorial).
-3. [Scaffold your own hApp](https://github.com/holochain/scaffolding) using our RAD tool.
+3. [Scaffold your own hApp](../happ-setup/#scaffolding-a-new-happ/) using our RAD tool.
 3. Build your development skills in the [Holochain Gym](https://holochain-gym.github.io/) (community-created).
 4. Learn more about Rust in the [Rust book](https://doc.rust-lang.org/book/).
 5. Take a look at the developer documentation.

--- a/src/install.md
+++ b/src/install.md
@@ -243,7 +243,54 @@ The next time you enter your hApp development environment using `nix-shell`, the
 
 > Keep in mind that the Holonix repo includes Nix configurations for the last ~ 5 versions of Holochain. That means that if you keep updating its revision using `niv`, you will have to augment the Holochain version id in `default.nix` sooner or later too.
 
-### Advanced usage
+### Holochain inspection commands
+
+Built into Holochain are a few commands that give insight about versions of Holochain components.
+
+```bash
+ hn-introspect
+```
+
+This command displays versioning information about Holochain's main components as well as Rust and Cargo. The output looks like this:
+
+```bash
+List of applications and their version information
+
+v0_0_131
+- hc-0.0.32-dev.0: https://github.com/holochain/holochain/tree/holochain-0.0.131
+- holochain-0.0.131: https://github.com/holochain/holochain/tree/holochain-0.0.131
+- kitsune-p2p-tx2-proxy-0.0.21: https://github.com/holochain/holochain/tree/holochain-0.0.131
+- lair-keystore-0.0.9: https://github.com/holochain/lair/tree/v0.0.9
+
+- rustc: rustc 1.58.1 (db9d1b20b 2022-01-20)
+- cargo fmt: rustfmt 1.4.38-stable (db9d1b20 2022-01-20)
+- cargo clippy: clippy 0.1.58 (db9d1b20 2022-01-20)
+```
+
+Another Holochain command that inspects the platform information and outputs the compatible HDK version is
+
+```bash
+holochain --build-info
+```
+
+A sample output of this command looks like this (JSON formmatted using `jq`):
+
+```json
+{
+  "git_info": null,
+  "cargo_pkg_version": "0.0.131",
+  "hdk_version_req": "0.0.126",
+  "timestamp": "2022-04-10T05:55:04.525835Z",
+  "hostname": "Mac-1649560170558.local",
+  "host": "x86_64-apple-darwin",
+  "target": "x86_64-apple-darwin",
+  "rustc_version": "rustc 1.58.1 (db9d1b20b 2022-01-20)",
+  "rustflags": "",
+  "profile": "release"
+}
+```
+
+### Advanced installation guide
 
 Read through our [advanced installation guide](../install-advanced/) for tips and tricks on making your development environment easier to work with, or what to do in case you need to work offline.
 

--- a/src/install.md
+++ b/src/install.md
@@ -298,7 +298,7 @@ Read through our [advanced installation guide](../install-advanced/) for tips an
 
 1. Read through the [Holochain Core Concepts](../concepts/).
 2. Try [building and running a sample hApp](https://github.com/holochain/happ-build-tutorial).
-3. [Scaffold your own hApp](../happ-setup/#scaffolding-a-new-happ/) using our RAD tool.
+3. [Scaffold your own hApp](../happ-setup/#scaffolding-a-new-happ) using our RAD tool.
 3. Build your development skills in the [Holochain Gym](https://holochain-gym.github.io/) (community-created).
 4. Learn more about Rust in the [Rust book](https://doc.rust-lang.org/book/).
 5. Take a look at the developer documentation.

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -48,7 +48,7 @@
             {{ config.site_name }}
           {% else %}
             <span class="md-header-nav__topic">
-              {{ config.site_name }} <span class="version"><a href="/changelog" title="Changelog">v0.5.5</a></span>
+              {{ config.site_name }} <span class="version"><a href="/changelog" title="Changelog">v0.5.6</a></span>
             </span>
             <span class="md-header-nav__topic">
               {% if page and page.meta and page.meta.title %}


### PR DESCRIPTION
added a section on commands to get versioning info about Holochain:
- `hn-introspect`
- `holochain --build-info`

added a new page on how to scaffold a hApp using
- `hn-init`
- `holochain-create`
and on how to run a packaged hApp with the Holochain Launcher.

@pdaoust @steveeJ I'd love some feedback on these changes from you guys.

Here's the preview https://deploy-preview-317--fervent-tesla-2a3da2.netlify.app/