### PR TITLE
Add migration page to concepts menu

### DIFF
--- a/src/concepts/index.md
+++ b/src/concepts/index.md
@@ -60,4 +60,9 @@ We’ve written this introduction for programmers, CTOs, and other technically o
             <h4>9. Signals</h4>
         </a>
     </div>
+    <div class="h-tile tile-alt tile-concepts">
+        <a href="10_migration">
+            <h4>10. Migration</h4>
+        </a>
+    </div>
 </div>


### PR DESCRIPTION
Without a link from the menu, it's very hard to discover this page. I only became aware of it from a [forum post](https://forum.holochain.org/t/updating-the-source-code-is-going-to-create-a-new-chain/7885). As a newbie to hApps, the absence of a page discussing how to upgrade code was very concerning in light of all the other statements I found about code hash changes creating a new chain:

> One of the most important characteristics of a DNA is that it's identified by the hash of the source-code. It follows that if you change something from that code and install that DNA again, you are literally creating a new network.