### PR TITLE
Remove happ-build-tutorial and happ-client-call-tutorial references, since they're "deprecated"

### DIFF
--- a/src/concepts/2_application_architecture.md
+++ b/src/concepts/2_application_architecture.md
@@ -132,7 +132,3 @@ You can see that Holochain is different from typical application stacks. Here's 
 * Zomes don’t maintain any in-memory state between calls; state is maintained in the history of the cell that contains the zome.
 * Persistence logic and core business logic are mixed together in your DNA, because at its heart, Holochain is a framework for data validation. However, you usually don’t need a lot of your business logic in your DNA—just enough to encode the ‘rules of the game’ for your application.
 * As with microservices, Holochain lends itself to combining small, reusable components into large applications.
-
-## Learn more
-
-If you want to go from theory to practice, you can learn hands-on how applications talk to hApps by reading and following the [hApp client call tutorial](https://github.com/holochain/happ-client-call-tutorial), which has examples in Typescript and Rust.

--- a/src/learning.md
+++ b/src/learning.md
@@ -34,8 +34,3 @@ The Holochain Gym is a practical approach to learning Holochain's concepts. In a
 Check it out at <https://holochain-gym.github.io>.
 
 ![](../img/holochain-gym.jpg)
-
-### hApp Build Tutorials
-
-Write your first hApp with this kickstart tutorial on [how to build a hApp](https://github.com/holochain/happ-build-tutorial).
-Once built, you can see how to call it from a client following this [hApp client call tutorial](https://github.com/holochain/happ-client-call-tutorial).

--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -9,16 +9,6 @@ This section lists additional published resources for Holochain developers. It w
         </a>
     </div>
     <div class="h-tile tile-alt tile-concepts">
-        <a href="https://github.com/holochain/happ-build-tutorial" target="_blank">
-            <h4>Example "First hApp" Repo With Instructions</h4>
-        </a>
-    </div>
-    <div class="h-tile tile-alt tile-concepts">
-        <a href="https://github.com/holochain/happ-client-call-tutorial" target="_blank">
-            <h4>"How To Call Your hApp" Explainer & Tutorial</h4>
-        </a>
-    </div>
-    <div class="h-tile tile-alt tile-concepts">
         <a href="https://github.com/holochain-open-dev/wiki/wiki" target="_blank">
             <h4>Community Curated Wiki: help with how-tos and common blockers</h4>
         </a>


### PR DESCRIPTION
@zippy deprecated happ-build-tutorial so I did the same for happ-client-call-tutorial and so removing them from being linked from developer.holochain.org

Also suggested to @zippy that happ-build-tutorial be unpinned from the Holochain Github org