### PR TITLE
fix lair-keystore installation instruction

### DIFF
--- a/src/install-without-holonix.md
+++ b/src/install-without-holonix.md
@@ -38,5 +38,5 @@ from the crate registry. At first the required Rust toolchain and features are i
 ```
 cargo install holochain -f
 cargo install holochain_cli -f
-cargo install lair_keystore -f --version '^0.0'
+cargo install lair_keystore -f
 ```


### PR DESCRIPTION
holochain is up to date using lair 0.2.0 and up now