### PR TITLE
remove outdated tips

### DIFF
--- a/src/install-advanced.md
+++ b/src/install-advanced.md
@@ -6,23 +6,10 @@ hide:
 # Advanced installation guide, tips and tricks
 
 <div markdown="1" class="coreconcepts-intro">
-This guide assumes that you've already followed the [quick installation guide](../install/) and want something more. It describes how to make it faster to get into the Holonix shell, explains how to install more or less stable versions of Holochain, and discusses why we use nix-shell in the first place.
+This guide assumes that you've already followed the [quick installation guide](../install/) and want something more. It describes how to use your default shell and preferred code editor with Nix, explains how to install more or less stable versions of Holochain, and discusses why we use nix-shell in the first place.
 </div>
 
-## Getting into Holonix faster and easier
-
-You might find it tedious to try to remember the command that gets you back into the Holonix development shell. `nix-shell https://holochain.love` isn't that intuitive, and when you're trying to open multiple terminals at a time for testing purposes it could get annoying.
-
-To save keystrokes, add an alias to your shell config:
-
-```bash
-echo 'alias holonix=\'nix-shell https://holochain.love' >> ~/.bashrc
-holonix
-```
-
-Close your terminal window, open it again, and you should be able to type `holonix` from now on to get into the shell.
-
-### Using your favorite shell
+### Using your default shell
 
 Many developers have their shell set up just the way they like it, whether a custom-formatted prompt or a completely different shell such as `zsh` and `fish`. If you don't want Holonix to clobber your carefully-crafted environment, try adding `--run $SHELL` to the end of your `nix-shell` command:
 
@@ -129,22 +116,6 @@ A sample output of this command looks like this (JSON formmatted using `jq`):
 }
 ```
 
-## Uninstalling
-
-You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. On macOS it adds users and a user group too. If you want to free up some space, run these commands:
-
-```bash
-nix-collect-garbage -d
-```
-
-If you want to uninstall Nix as well, run these commands (you might need root privileges for the first line):
-
-```bash
-rm -rf /nix
-rm ~/.nix-profile
-```
-[Detailed uninstallation instructions for macOS](https://gist.github.com/chriselsner/3ebe962a4c4bd1f14d39897fc5619732#uninstalling-nix)
-
 ## More info on Nix
 
 We use the Nix/NixOS toolkit to build consistent development, testing, and deployment environments for Holochain Core and apps. It consists of two systems:
@@ -169,7 +140,23 @@ The full suite of Nix tooling is broad and deep. There’s even a dedicated prog
 
 While working on Holochain, you will usually have an active `nix-shell` to run commands. This shell overlays Holochain-specific configuration on top of your existing shell---environment variables, Rust toolchains, binaries, libraries, and development tools---giving you a consistent development environment to build Holochain apps. All this setup will be cleaned up automatically when you close the shell.
 
-If you want to re-enter the shell to do more work, or create multiple terminals to work in, you'll need to re-enter the `nix-shell`. The packages are cached locally on your machine, so they will be ready the next time you enter the shell. You do need to get the package configuration files from somewhere, though. If you use the [Holochain repo cloning method](#keeping-everything-local), they're cached on your machine too, but the ['quick install'](../install/) and ['using a specific version'](#using-a-specific-version-of-the-development-tools) methods require an internet connection every time you want to enter the shell.
+If you want to re-enter the shell to do more work, or create multiple terminals to work in, you'll need to re-enter the `nix-shell`. The packages are cached locally on your machine, so they will be ready the next time you enter the shell. You do need to get the package configuration files from somewhere, though. If you use the Holochain repo cloning method, they're cached on your machine too, but the ['quick install'](../install/) and ['using a specific version'](#using-a-specific-version-of-the-development-tools) methods require an internet connection every time you want to enter the shell.
+
+## Uninstalling Nix
+
+You usually don't need to uninstall anything, because `nix-shell` leaves your familiar user environment alone and makes all of its own changes disappear once you exit the shell. But it does keep binaries and other packages on your device. On macOS it adds users and a user group too. If you want to free up some space, run these commands:
+
+```bash
+nix-collect-garbage -d
+```
+
+If you want to uninstall Nix as well, run these commands (you might need root privileges for the first line):
+
+```bash
+rm -rf /nix
+rm ~/.nix-profile
+```
+[Detailed uninstallation instructions for macOS](https://gist.github.com/chriselsner/3ebe962a4c4bd1f14d39897fc5619732#uninstalling-nix)
 
 ## Install Holochain without Holonix
 


### PR DESCRIPTION
I can't tell what will remain valid after the Nix dev shell refactoring is complete. For the time being I suggest what's in here.