### PR TITLE
refactor(deploy): move from happ-setup to get-building

### DIFF
--- a/src/pages/get-building/distribute-your-app.md
+++ b/src/pages/get-building/distribute-your-app.md
@@ -1,3 +1,25 @@
 ---
 title: Distribute your App
 ---
+
+## Packaging a Web-hApp archive
+
+At some stage in the app development you'll want to deploy your hApp for others to use it. For this, you will need to package it into a `.webhapp` file that contains both the back-end and the front-end code of your hApp.
+
+If you've created the hApp with the `hc scaffold` cli tool, all you need to do is:
+
+```bash
+npm run package
+```
+
+The app bundle ending in `.webhapp` will be available in the project root's `workdir` folder. Now you can deploy it to a place where users can download it or directly share it with peers you want to use it with.
+
+To bundle manually and for extended details on Web-hApps, refer to the packaging steps in the [Github repo of the Holochain Launcher](https://github.com/holochain/launcher#packaging-a-web-happ).
+
+## Installing the app using the Holochain Launcher
+
+Holochain provides the Holochain Launcher, a graphical user interface, to install, run and administrate hApps. [Download Holochain Launcher](https://github.com/holochain/launcher/releases)
+
+To publicly share your bundled hApp through the Holochain Launcher, follow the [instructions on how to publish it to the DevHub](https://github.com/holochain/launcher#publishing-a-webhapp-to-the-devhub) in the README of the Holochain Launcher.
+
+Another option is to install a hApp locally from an app bundle on the file system ([1.b) in the Launcher README](https://github.com/holochain/launcher#installing-a-happ)). Other users will need to obtain the bundled app file and install it to their Launcher.

--- a/src/pages/happ-setup.md
+++ b/src/pages/happ-setup.md
@@ -82,21 +82,3 @@ When you use the Scaffolding Tool to generate your sample project, it will creat
 ```
 
 You can enter the Holochain nix-shell and immediately start developing your hApp.
-
-## Distribute and Run your hApp
-
-At some stage in the app development you'll want to deploy your hApp for others to use it. For this, you will need to package it into a `.webhapp` file that contains both the backend and the front-end code of your hApp.
-
-If you've created the hApp with the `hc scaffold` cli tool, all you need to do is:
-
-```bash
-npm run package
-```
-
-The app bundle ending in `.webhapp` will be available in the project root's `workdir` folder. Now you can deploy it to a place where users can download it or directly share it with peers you want to use it with.
-
-To run a `.webhapp` file on your computer, Holochain provides the Holochain Launcher, a graphical user interface to install, run and administrate Holochain apps.
-
-[Download Holochain Launcher](https://github.com/holochain/launcher/releases)
-
-To publicly share your bundled hApp via the Holochain Launcher, follow the [instructions](https://github.com/holochain/launcher#publishing-a-webhapp-to-the-devhub) in the README of the Holochain Launcher.


### PR DESCRIPTION
### Changed
Moved instructions to distribute hApp from "hApp Setup" to "Distribute your app".