### PR TITLE
Set up redirect for the quick-start

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -82,3 +82,10 @@
     from = "/install/"
     to = "/quick-start/"
     status = 301
+
+# The front page for the core concepts has been removed.
+[[redirects]]
+    from = "/concepts/"
+    to = "/concepts/1_the_basics/"
+    # Keeping this as a 302 in case we decide we want a front page again.
+    status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -62,7 +62,7 @@
 # Super old install URL; used to be incorrectly linked from the blog's CTAs.
 [[redirects]]
     from = "/start.html"
-    to = "/install/"
+    to = "/quick-start/"
     status = 301
 
 # This is just for the nix guide, which is now called the advanced install guide.
@@ -75,4 +75,10 @@
 [[redirects]]
     from = "/assets/files/RRDHT-draft-Nov-2019.pdf"
     to = "/assets/files/RRDHT-whitepaper-final.pdf"
+    status = 301
+    
+# The quick start guide used to live at /install/
+[[redirects]]
+    from = "/install/"
+    to = "/quick-start/"
     status = 301


### PR DESCRIPTION
There are a lot of inbound links to `/install/` in the wild, so it's important to 301 them to the right spot.