### PR TITLE
rename 'Core Concepts' to 'Learn' -- but only in the menus

### DIFF
--- a/src/pages/_data/navigation/footerLinks.json5
+++ b/src/pages/_data/navigation/footerLinks.json5
@@ -4,7 +4,7 @@
       title: "Developers",
       links: [
         { title: "Get Started", url: "/get-started/" },
-        { title: "Core Concepts", url: "/concepts/1_the_basics/" },
+        { title: "Learn", url: "/concepts/1_the_basics/" },
         { title: "Resources", url: "/resources/" },
       ]
     },

--- a/src/pages/_data/navigation/headerNav.json5
+++ b/src/pages/_data/navigation/headerNav.json5
@@ -1,7 +1,7 @@
 {
   links: [
     { title: "Get Started", url: "/get-started/", class:"" },
-    { title: "Core Concepts", url: "/concepts/1_the_basics/", class:"" },
+    { title: "Learn", url: "/concepts/1_the_basics/", class:"" },
     { title: "Resources", url: "/resources/", class:"" },
     { title: "Get Involved", url: "/get-involved/", class:"" },
   ]

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -12,7 +12,7 @@
         { title: "Setup For a Local Event", url: "/get-started/at-an-event/" },
       ]
     },
-    { title: "Core Concepts", url: "/concepts/1_the_basics/", children: [
+    { title: "Learn", url: "/concepts/1_the_basics/", children: [
         { title: "Application Architecture", url: "/concepts/2_application_architecture/" },
         { title: "Source Chain", url: "/concepts/3_source_chain/" },
         { title: "DHT", url: "/concepts/4_dht/" },


### PR DESCRIPTION
This is the reduced scope of #433 -- I decided that 'core concepts' will be a useful header when we add more learning resources under a 'Learn' header. I've kept the URLs as they are; once we add more content we'll want a landing page for all the different types of concepts, and then I'll move `/concepts` to `/learn/concepts` and set up a redirect.