### PR TITLE
Feat/auto-generated TOCs

### DIFF
--- a/11ty-extensions/index.js
+++ b/11ty-extensions/index.js
@@ -5,6 +5,10 @@ import NunjucksExt from "./nunjucks-exts.js";
 import Transforms from "./eleventy-transforms.js";
 
 export default function(eleventyConfig) {
+  // The markdown-it-config.js file isn't set up as an Eleventy extension.
+  // Instead, it just loads up Markdown-it and adds extensions, then exports
+  // that extended config. This is so it can be used by both Eleventy here, and
+  // by the TOC generator in /src/pages/_data/eleventyComputed.js
   eleventyConfig.setLibrary("md", CustomMarkdownIt);
   LayoutBlockShortcodes(eleventyConfig);
   CardShortcodes(eleventyConfig);

--- a/11ty-extensions/index.js
+++ b/11ty-extensions/index.js
@@ -1,11 +1,11 @@
-import ConfigMarkdownIt from "./markdown-it-config.js";
+import CustomMarkdownIt from "./markdown-it-config.js";
 import LayoutBlockShortcodes from "./layout-block-shortcodes.js";
 import CardShortcodes from "./card-shortcodes.js";
 import NunjucksExt from "./nunjucks-exts.js";
 import Transforms from "./eleventy-transforms.js";
 
 export default function(eleventyConfig) {
-  ConfigMarkdownIt(eleventyConfig);
+  eleventyConfig.setLibrary("md", CustomMarkdownIt);
   LayoutBlockShortcodes(eleventyConfig);
   CardShortcodes(eleventyConfig);
   NunjucksExt(eleventyConfig);

--- a/11ty-extensions/markdown-it-config.js
+++ b/11ty-extensions/markdown-it-config.js
@@ -88,7 +88,13 @@ const validateDetailsBlock = (params) => {
 
 const mdLib = markdownIt();
 
-mdLib.set({ typographer: true });
+// Set up sane defaults; most of these are borrowed from 11ty's defaults.
+mdLib.set({
+  html: true,
+  linkify: true,
+  typographer: true
+});
+mdLib.disable("code");
 
 //Configure markdown-it plugins
 mdLib.use(markdownItAttrs);

--- a/11ty-extensions/markdown-it-config.js
+++ b/11ty-extensions/markdown-it-config.js
@@ -1,3 +1,4 @@
+import markdownIt from "markdown-it";
 import markdownItAttrs from "markdown-it-attrs";
 import markdownItContainer from "markdown-it-container";
 import markdownItAnchor from "markdown-it-anchor";
@@ -80,32 +81,33 @@ const validateDetailsBlock = (params) => {
  * Configures Markdown-it lib plugins etc. Meant to be called from .eleventy.js
  * @param {*} eleventyConfig
  */
-export default function(eleventyConfig) {
-  eleventyConfig.amendLibrary("md", (mdLib) => {
-    mdLib.set({ typographer: true });
 
-    //Configure markdown-it plugins
-    mdLib.use(markdownItAttrs);
-    mdLib.use(markdownItAnchor, {
-      tabIndex: false,
-      slugify: s => slugify(s),
-      permalink: markdownItAnchor.permalink.headerLink(),
-    });
-    mdLib.use(markdownItContainer, "intro");
-    mdLib.use(markdownItContainer, "orientation");
-    mdLib.use(markdownItContainer, "storystep");
-    mdLib.use(markdownItContainer, "h-author");
-    mdLib.use(markdownItContainer, "output-block");
+const mdLib = markdownIt();
 
-    // Admonitions
-    mdLib.use(markdownItContainer, "tip", { marker: "!", render: composeGenericAdmonitionRenderFunc("tip") });
-    mdLib.use(markdownItContainer, "note", { marker: "!", render: composeGenericAdmonitionRenderFunc("note") });
-    mdLib.use(markdownItContainer, "info", { marker: "!", render: composeGenericAdmonitionRenderFunc("info") });
-    mdLib.use(markdownItContainer, "learn", { marker: "!", render: composeGenericAdmonitionRenderFunc("learn") });
+mdLib.set({ typographer: true });
 
-    // Details block
-    mdLib.use(markdownItContainer, "details", { marker: "!", render: composeDetailsBlockRenderFunc() });
-    // Create a specialized synonym for details block with a class of "dig-deeper"
-    mdLib.use(markdownItContainer, "dig-deeper", { marker: "!", render: composeDetailsBlockRenderFunc("dig-deeper") });
-  });
-};
+//Configure markdown-it plugins
+mdLib.use(markdownItAttrs);
+mdLib.use(markdownItAnchor, {
+  tabIndex: false,
+  slugify: s => slugify(s),
+  permalink: markdownItAnchor.permalink.headerLink(),
+});
+mdLib.use(markdownItContainer, "intro");
+mdLib.use(markdownItContainer, "orientation");
+mdLib.use(markdownItContainer, "storystep");
+mdLib.use(markdownItContainer, "h-author");
+mdLib.use(markdownItContainer, "output-block");
+
+// Admonitions
+mdLib.use(markdownItContainer, "tip", { marker: "!", render: composeGenericAdmonitionRenderFunc("tip") });
+mdLib.use(markdownItContainer, "note", { marker: "!", render: composeGenericAdmonitionRenderFunc("note") });
+mdLib.use(markdownItContainer, "info", { marker: "!", render: composeGenericAdmonitionRenderFunc("info") });
+mdLib.use(markdownItContainer, "learn", { marker: "!", render: composeGenericAdmonitionRenderFunc("learn") });
+
+// Details block
+mdLib.use(markdownItContainer, "details", { marker: "!", render: composeDetailsBlockRenderFunc() });
+// Create a specialized synonym for details block with a class of "dig-deeper"
+mdLib.use(markdownItContainer, "dig-deeper", { marker: "!", render: composeDetailsBlockRenderFunc("dig-deeper") });
+
+export default mdLib;

--- a/11ty-extensions/markdown-it-config.js
+++ b/11ty-extensions/markdown-it-config.js
@@ -4,6 +4,10 @@ import markdownItContainer from "markdown-it-container";
 import markdownItAnchor from "markdown-it-anchor";
 import slugify from '@sindresorhus/slugify';
 
+// This config is shared by Eleventy and by the TOC generator in /src/pages/_data/eleventyComputed.js
+// which is why it has no Eleventy stuff in it like the other files in this
+// folder.
+
 /**
  * Composes the attributes string for an html tag from the markdown-it-container token and default attributes
  * @param {*} token token from markdown-it-container

--- a/11ty-markdown-changes.md
+++ b/11ty-markdown-changes.md
@@ -49,6 +49,31 @@ Obviously it would be optimal to actually resize the image. But you can tweak th
 ![](/assets/img/concepts/8.1-calls.png){.sz50p}
 ```
 
+## Table of contents
+An on-page table of contents is generated automatically for every page from all `h2` to `h6` elements that have `id` attributes. If you don't want this to happen, put `tocData: false` in your page's front matter.
+
+If you want to craft a custom table of contents, instead assign a nested array to `tocData` that looks like this:
+
+```yaml
+tocData:
+  - text: First section header
+    href: first-section-header
+    children:
+      - text: Subsection header 1
+        href: subsection-header-1
+      - text: Subsection header 2
+        href: subsection-header-2
+  - text: Second section header
+    href: second-section-header
+  - text: Conclusion
+    href: conclusion
+```
+
+There are two things to note about the above:
+
+* IDs are automatically generated for all headers; they'll be the slug of the header text. You can override a header's ID with a `{#custom-id}` attribute.
+* Although the `href` property suggests it should be a resolvable URL, don't put the `#` at the beginning of its value.
+
 ## Items to add to README
 - using callMacroByName
 

--- a/src/pages/_data/eleventyComputed.js
+++ b/src/pages/_data/eleventyComputed.js
@@ -1,6 +1,17 @@
 import CustomMarkdownIt from "../../../11ty-extensions/markdown-it-config.js";
 import DOM from "fauxdom";
 
+// This file generates on-page TOC for every Markdown page that doesn't disable
+// this feature via a `tocData` property in the front matter.
+// See the `Table of contents` section of `/11ty-markdown-changes.md` for info.
+//
+// Note that this passes the `data.page.rawInput` data property through
+// Markdown-it so it has access to the HTML for generating the outline.
+// `rawInput` is a new property as of 11ty 3.0.0: https://github.com/11ty/eleventy/issues/1206#issuecomment-1885269900
+// So that means it parses every Markdown page twice. Yes, I know that's a
+// performance hit, but 11ty doesn't let you generate computed data from the
+// content _after_ it's been converted to HTML.
+
 function generateOutline(content) {
   const doc = new DOM(content);
   let headers = doc.querySelectorAll(":is(h2, h3, h4, h5, h6)[id]:not([data-no-toc])")

--- a/src/pages/_data/eleventyComputed.js
+++ b/src/pages/_data/eleventyComputed.js
@@ -1,0 +1,59 @@
+import CustomMarkdownIt from "../../../11ty-extensions/markdown-it-config.js";
+import DOM from "fauxdom";
+
+function generateOutline(content) {
+  const doc = new DOM(content);
+  let headers = doc.querySelectorAll(":is(h2, h3, h4, h5, h6)[id]:not([data-no-toc])")
+    .map(el => {
+      return {
+        level: Number(el.tagName.substring(1, 2)),
+        text: el.textContent.trim(),
+        href: el.id
+      };
+    });
+
+  function buildOutlineRecursive(headers, currentLevel = 2) {
+    const nestedSection = [];
+
+    if (headers.length) {
+      for (let i = 0; i < headers.length; i++) {
+        const header = headers[i];
+
+        if (header.level < currentLevel) {
+          break;
+        }
+
+        if (header.level == currentLevel) {
+          let node = {
+            text: header.text,
+            href: header.href
+          };
+
+          let children = buildOutlineRecursive(
+            headers.slice(i + 1),
+            header.level + 1
+          );
+
+          if (children.length) {
+            node.children = children;
+          }
+
+          nestedSection.push(node);
+        }
+      }
+    }
+
+    return nestedSection;
+  }
+
+  return buildOutlineRecursive(headers);
+}
+
+export default {
+  generatedTocData: function(data) {
+    if (data.page.templateSyntax.endsWith("md") && data.tocData === undefined) {
+      const html = CustomMarkdownIt.render(data.page.rawInput);
+      return generateOutline(html);
+    }
+  }
+};

--- a/src/pages/_includes/default-page-layout.njk
+++ b/src/pages/_includes/default-page-layout.njk
@@ -13,7 +13,8 @@ surpressH1InLayout: false
 </div>
 <div class="side-bar">
   {{ mainNavTree(navigation.mainNav, page) }}
-  {{ tocBlock(tocData) }} 
+  {% set toc = tocData or generatedTocData %}
+  {{ tocBlock(toc) }}
 </div>
 
 <div class="header-full-bg"></div>

--- a/src/pages/_includes/widgets/navigation.njk
+++ b/src/pages/_includes/widgets/navigation.njk
@@ -61,7 +61,7 @@
 {% endmacro %}
 
 {% macro tocBlock(tocData) %}
-{% if tocData %}
+{% if tocData and tocData|length %}
   <nav id="in-page-toc">
     <h2>On this page</h2>
     <ul>

--- a/src/pages/concepts/2_application_architecture.md
+++ b/src/pages/concepts/2_application_architecture.md
@@ -1,5 +1,6 @@
 ---
 title: Application Architecture
+tocData: false
 ---
 
 ::: intro


### PR DESCRIPTION
This feature adds an auto-generated table of contents to every Markdown page, unless disabled by the page's front matter with `tocData: false` or an explicit TOC value for `tocData`. Comes with documentation and everything.