### PR TITLE
Recommend cargo update in upgrade guides

### DIFF
--- a/src/pages/resources/upgrade/upgrade-holochain-0.2.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.2.md
@@ -245,6 +245,19 @@ Once you've updated your `Cargo.toml` you need to update your `Cargo.lock` and c
 cargo build
 ```
 
+### (Optional) Update other Rust dependencies
+
+Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies
+to resolve build issues. 
+
+This section is marked as optional because it's possible that new dependencies could introduce new issues as well as fixing existing conflicts or problems. To make it possible to roll back this change, it might be a good idea to commit the changes you've made so far to source control. Then you can run:
+
+```
+cargo update
+```
+
+This will update your `Cargo.lock` with the latest versions of all libraries that the constraints in your `Cargo.toml` files will allow. Now you should try building your project again to see if that has resolved your issue.
+
 ### Dealing with API changes in the HDK and HDI
 
 You are likely to run into API changes in the HDK and HDI at this point. You can check the [Holochain changelog](https://github.com/holochain/holochain/blob/develop-0.2/CHANGELOG.md) to see what has changed. In some cases there will be guidance for what you need to change.

--- a/src/pages/resources/upgrade/upgrade-holochain-0.2.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.2.md
@@ -247,12 +247,11 @@ cargo build
 
 ### (Optional) Update other Rust dependencies
 
-Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies
-to resolve build issues. 
+Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies to resolve build issues. 
 
 This section is marked as optional because it's possible that new dependencies could introduce new issues as well as fixing existing conflicts or problems. To make it possible to roll back this change, it might be a good idea to commit the changes you've made so far to source control. Then you can run:
 
-```
+```shell
 cargo update
 ```
 

--- a/src/pages/resources/upgrade/upgrade-holochain-0.3.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.3.md
@@ -199,6 +199,19 @@ Once you've updated your `Cargo.toml` you need to update your `Cargo.lock` and c
 cargo build
 ```
 
+### (Optional) Update other Rust dependencies
+
+Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies
+to resolve build issues.
+
+This section is marked as optional because it's possible that new dependencies could introduce new issues as well as fixing existing conflicts or problems. To make it possible to roll back this change, it might be a good idea to commit the changes you've made so far to source control. Then you can run:
+
+```
+cargo update
+```
+
+This will update your `Cargo.lock` with the latest versions of all libraries that the constraints in your `Cargo.toml` files will allow. Now you should try building your project again to see if that has resolved your issue.
+
 ### Dealing with API changes in the HDK and HDI
 
 You are likely to run into API changes in the HDK and HDI at this point. You can check the [Holochain changelog](https://github.com/holochain/holochain/blob/develop-0.3/CHANGELOG.md) to see what has changed. In some cases there will be guidance for what you need to change.

--- a/src/pages/resources/upgrade/upgrade-holochain-0.3.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.3.md
@@ -201,12 +201,11 @@ cargo build
 
 ### (Optional) Update other Rust dependencies
 
-Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies
-to resolve build issues.
+Running a Cargo build, like suggested above, will update as few dependencies as it can. This is good for stability because it's just making the changes you asked for. However, sometimes you do need to update other dependencies to resolve build issues.
 
 This section is marked as optional because it's possible that new dependencies could introduce new issues as well as fixing existing conflicts or problems. To make it possible to roll back this change, it might be a good idea to commit the changes you've made so far to source control. Then you can run:
 
-```
+```shell
 cargo update
 ```
 


### PR DESCRIPTION
I've had two reports now for people upgrading versions that the `time` package being on an older version has caused their WASM to not build. The solution to this has just been to `cargo update`, so I thought I'd add a section to the upgrade guides to mention this.