### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/src/pages/get-started/install-advanced.md
+++ b/src/pages/get-started/install-advanced.md
@@ -56,7 +56,7 @@ mkdir -p ~/.config/nix
 echo "extra-experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ```
 
-To learn more, please see the [Enable flakes section on the NixOS Wiki](https://nixos.wiki/wiki/Flakes#Enable_flakes).
+To learn more, please see the [Enable flakes section on the NixOS Wiki](https://wiki.nixos.org/wiki/Flakes#Enable_flakes).
 
 ### The anatomy of a `flake.nix`
 
@@ -240,7 +240,7 @@ It is important that these remain consistent, so you can get your work done with
 
 The main Nix tool used in Holochain development workflows is `nix develop`, a program that overlays a new Bash environment and set of tools on top of your existing shell environment.
 
-The full suite of Nix tooling is broad and deep. There's even a dedicated programming language, called [Nix expressions](https://nixos.org/manual/nix/stable/#functional-package-language). Learn more with the [NixOS Wiki](https://nixos.wiki) or the [Pills](https://nixos.org/nixos/nix-pills/) Tutorial. The [NixOS community chat on matrix.to](https://matrix.to/#/#community:nixos.org) is active and helpful.
+The full suite of Nix tooling is broad and deep. There's even a dedicated programming language, called [Nix expressions](https://nixos.org/manual/nix/stable/#functional-package-language). Learn more with the [NixOS Wiki](https://wiki.nixos.org) or the [Pills](https://nixos.org/nixos/nix-pills/) Tutorial. The [NixOS community chat on matrix.to](https://matrix.to/#/#community:nixos.org) is active and helpful.
 
 ### `nix develop`
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️