### PR TITLE
Build guide: zome functions and lifecycle callbacks

### DIFF
--- a/.cspell/words-that-should-exist.txt
+++ b/.cspell/words-that-should-exist.txt
@@ -25,6 +25,7 @@ runtimes
 sandboxed
 sandboxing
 scaffolder
+snapshotted
 spacebar
 todo
 todos

--- a/code_test_4/web-happ.yaml
+++ b/code_test_4/web-happ.yaml
@@ -1,0 +1,6 @@
+manifest_version: '1'
+name: blup
+ui:
+  bundled: ./path/to/my/ui.zip
+happ_manifest:
+  bundled: ./path/to/my/happ-bundle.happ

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -26,7 +26,10 @@
     },
     { title: "Build", url: "/build/", children: [
         { title: "Application Structure", url: "/build/application-structure/", children: [
-          { title: "Zomes", url: "/build/zomes/" },
+          { title: "Zomes", url: "/build/zomes/", children: [
+            { title: "Lifecycle Events and Callbacks", url: "/build/lifecycle-events-and-callbacks/" },
+            { title: "Zome Functions": url: "/build/zome-functions/" },
+          ] },
         ]},
         { title: "Working with Data", url: "/build/working-with-data/", children: [
           { title: "Identifiers", url: "/build/identifiers/" },

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -28,7 +28,7 @@
         { title: "Application Structure", url: "/build/application-structure/", children: [
           { title: "Zomes", url: "/build/zomes/", children: [
             { title: "Lifecycle Events and Callbacks", url: "/build/lifecycle-events-and-callbacks/" },
-            { title: "Zome Functions": url: "/build/zome-functions/" },
+            { title: "Zome Functions", url: "/build/zome-functions/" },
           ] },
         ]},
         { title: "Working with Data", url: "/build/working-with-data/", children: [

--- a/src/pages/_data/navigation/mainNav.json5
+++ b/src/pages/_data/navigation/mainNav.json5
@@ -27,7 +27,7 @@
     { title: "Build", url: "/build/", children: [
         { title: "Application Structure", url: "/build/application-structure/", children: [
           { title: "Zomes", url: "/build/zomes/", children: [
-            { title: "Lifecycle Events and Callbacks", url: "/build/lifecycle-events-and-callbacks/" },
+            { title: "Lifecycle Events and Callbacks", url: "/build/callbacks-and-lifecycle-hooks/" },
             { title: "Zome Functions", url: "/build/zome-functions/" },
           ] },
         ]},

--- a/src/pages/build/application-structure.md
+++ b/src/pages/build/application-structure.md
@@ -7,7 +7,7 @@ title: Application Structure
 
 * Application Structure (this page)
     * [Zomes](/build/zomes/) --- integrity vs coordinator, how to structure and compile
-        * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+        * [Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/) --- writing functions that respond to events in a hApp's lifecycle
         * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
     * DNAs (coming soon) --- what they're used for, how to specify and bundle
     * hApps (coming soon) --- headless vs UI-based, how to bundle and distribute

--- a/src/pages/build/application-structure.md
+++ b/src/pages/build/application-structure.md
@@ -7,6 +7,8 @@ title: Application Structure
 
 * Application Structure (this page)
     * [Zomes](/build/zomes/) --- integrity vs coordinator, how to structure and compile
+        * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+        * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
     * DNAs (coming soon) --- what they're used for, how to specify and bundle
     * hApps (coming soon) --- headless vs UI-based, how to bundle and distribute
 :::

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -35,11 +35,11 @@ pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
 
 ### Define a `genesis_self_check` callback
 
-If your network needs to control who can and can't join it, you can write your DNA to require a [**membrane proof**](/resources/glossary/#membrane-proof), a small chunk of bytes that the app receives from the user at installation time and then stores on the source chain. You can then write validation rules for this record just like any other record.
+If your network needs to control who can and can't join it, you can write your DNA to require a [**membrane proof**](/resources/glossary/#membrane-proof), a small chunk of bytes that the app receives from the user at installation time and stores on the source chain. You can then write validation rules for this record just like any other record.
 
 There's one challenge with this: validation requires access to the network (a membrane proof may reference DHT data that contains a list of public keys authorized to grant access to newcomers, for instance), but the membrane proof is written at [**genesis**](/resources/glossary/#genesis-records) time when the cell doesn't have network access yet. So Holochain can't do the usual self-validation before publishing it.
 
-This means the agent could accidentally type or paste a malformed membrane proof and be rejected from the network. To guard against this, you can define a `genesis_self_check` function that runs at genesis time and checks the content of the membrane proof before it's written.
+This means someone could accidentally type or paste a malformed membrane proof and be rejected from the network. To guard against this, you can define a `genesis_self_check` function that runs at genesis time and checks the content of the membrane proof before it's written.
 
 `genesis_self_check` must take a single argument of type [`GenesisSelfCheckData`](https://docs.rs/hdi/latest/hdi/prelude/type.GenesisSelfCheckData.html) and return a value of type [`ValidateCallbackResult`](https://docs.rs/hdi/latest/hdi/prelude/enum.ValidateCallbackResult.html) wrapped in an `ExternResult`.
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -33,17 +33,6 @@ pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
 }
 ```
 
-And here's an example of one that rejects everything. You'll note that the outer result is `Ok`; you should generally reserve `Err` for unexpected failures such as inability to deserialize data. However, Holochain will treat both `Ok(Invalid)` and `Err` as invalid operations that should be rejected.
-
-```rust
-use hdi::prelude::*;
-
-#[hdk_extern]
-pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
-    Ok(ValidateCallbackResult::Invalid("I reject everything".into()))
-}
-```
-
 ### Define a `genesis_self_check` callback
 
 Holochain assumes that every agent is able to self-validate all the data they create before storing it on their [source chain](/concepts/3_source_chain/) and publishing it to the [DHT](/concepts/4_dht/). But at **genesis** time, when their cell has just been instantiated but they haven't connected to other peers, they may not be able to fully validate their [**genesis records**](/concepts/3_source_chain/#source-chain-your-own-data-store) if their validity depends on shared data. So Holochain skips full self-validation for these records, only validating the basic structure of their [actions](/build/working-with-data/#entries-actions-and-records-primary-data).

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -146,7 +146,7 @@ But if there are a lot of agents in the network, this can create "hot spots" whe
 
 !!!
 
-This `init` callback also does something useful: it grants all peers in the network permission to send messages to an agent's [remote signal receiver callback](#define-a-recv-remote-signal-callback).
+This `init` callback also does something useful: it grants all peers in the network permission to send messages to an agent's [remote signal receiver callback](#define-a-recv-remote-signal-callback). (Note that this can create a risk of spamming.) {#init-grant-unrestricted-access-to-recv-remote-signal}
 
 ```rust
 use hdk::prelude::*;
@@ -224,6 +224,10 @@ pub fn heartbeat(_: ()) -> ExternResult<()> {
     )
 }
 ```
+
+!!! info Remote signals and privileges
+If you grant unrestricted access to your remote signal callback like in the [previous example](init-grant-unrestricted-access-to-recv-remote-signal), take care that it does as little as possible, to avoid people abusing it. Permissions and privileges are another topic which we'll talk about soon.<!-- TODO: link when the capabilities page is written -->
+!!!
 
 ### Define a `post_commit` callback
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -10,7 +10,7 @@ All of the callbacks must follow the [pattern for public functions](/build/zomes
 
 ## Integrity zomes
 
-Your [integrity zome](/build/zomes/#integrity) may define three callbacks, `validate`, `entry_defs`, and `genesis_self_check`. All of these functions **cannot have side effects**; any attempt to write data will fail. They also cannot access data that changes over time or across agents, such as the current cell's [agent ID](/build/identifiers/#agent) or a collection of [links](/build/links-paths-and-anchors/) in the [DHT](/concepts/4_dht).
+Your [integrity zome](/build/zomes/#integrity) may define callbacks, `validate` and `genesis_self_check`. These functions **cannot have side effects**; any attempt to write data will fail. They also cannot access data that changes over time or across agents, such as the current cell's [agent ID](/build/identifiers/#agent) or a collection of [links](/build/links-paths-and-anchors/) in the [DHT](/concepts/4_dht).
 
 
 ### Define a `validate` callback
@@ -43,10 +43,6 @@ pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
     Ok(ValidateCallbackResult::Invalid("I reject everything".into()))
 }
 ```
-
-### Define an `entry_defs` callback
-
-You don't need to write this callback by hand; you can let the `hdk_entry_types` macro do it for you. Read the [Define an entry type section under Entries](/build/entries/#define-an-entry-type) to find out how.
 
 ### Define a `genesis_self_check` callback
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -322,3 +322,19 @@ pub fn update_movie(input: UpdateMovieInput) -> ExternResult<ActionHash> {
     }
 }
 ```
+
+## Reference
+
+* [`holochain_integrity_types::Op`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/op/enum.Op.html)
+* [`holochain_integrity_types::validate::ValidateCallbackResult`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/validate/enum.ValidateCallbackResult.html)
+* [`holochain_integrity_types::genesis::GenesisSelfCheckData`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/genesis/type.GenesisSelfCheckData.html)
+* [`holochain_integrity_types::action::InitZomesComplete`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.InitZomesComplete.html)
+* [`holochain_zome_types::init::InitCallbackResult`](https://docs.rs/holochain_zome_types/latest/holochain_zome_types/init/enum.InitCallbackResult.html)
+* [`hdk::p2p::send_remote_signal`](https://docs.rs/hdk/latest/hdk/p2p/fn.send_remote_signal.html)
+* [`hdk::p2p::emit_signal`](https://docs.rs/hdk/latest/hdk/p2p/fn.emit_signal.html)
+
+## Further reading
+
+* [Core Concepts: Lifecycle Events](/concepts/11_lifecycle_events/)
+* [Core Concepts: Signals](/concepts/9_signals/)
+* [Build Guide: Identifiers](/build/identifiers/)

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -205,7 +205,7 @@ pub fn heartbeat(_: ()) -> ExternResult<()> {
 ```
 
 !!! info Remote signals and privileges
-If you grant unrestricted access to your remote signal callback like in the [previous example](init-grant-unrestricted-access-to-recv-remote-signal), take care that it does as little as possible, to avoid people abusing it. Permissions and privileges are another topic which we'll talk about soon.<!-- TODO: link when the capabilities page is written -->
+If you grant unrestricted access to your remote signal callback like in the [previous example](#init-grant-unrestricted-access-to-recv-remote-signal), take care that it does as little as possible, to avoid people abusing it. Permissions and privileges are another topic which we'll talk about soon.<!-- TODO: link when the capabilities page is written -->
 !!!
 
 ### Define a `post_commit` callback

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -129,9 +129,9 @@ pub fn get_participant_registration_anchor_hash() -> ExternResult<EntryHash> {
 
 !!! info Why link the agent key to a well-known hash?
 
-Because there's no single source of truth in a Holochain network, it's impossible to get the full list of agents who have joined it. The above pattern is an easy way for newcomers to register themselves as active participants so others can find them.
+There's no such thing as a 'users table' in a Holochain DHT. The above pattern is an easy way for newcomers to register themselves as active participants so others can find them.
 
-But if there are a lot of agents in the network, this can create "hot spots" where one set of agents --- the ones responsible for storing the base address for all those links --- carry an outsized burden compared to other agents. Read the [anchors and paths section under Links, Paths, and Anchors](/build/links-paths-and-anchors/#anchors-and-paths) for more info.
+Note that this can create "hot spots" where some agents have a heavier data storage and network traffic burden than others. Read the [anchors and paths section under Links, Paths, and Anchors](/build/links-paths-and-anchors/#anchors-and-paths) for more info.
 
 !!!
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -35,9 +35,11 @@ pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
 
 ### Define a `genesis_self_check` callback
 
-Holochain assumes that every agent is able to self-validate all the data they create before storing it on their [source chain](/concepts/3_source_chain/) and publishing it to the [DHT](/concepts/4_dht/). But at **genesis** time, when their cell has just been instantiated but they haven't connected to other peers, they may not be able to fully validate their [**genesis records**](/concepts/3_source_chain/#source-chain-your-own-data-store) if their validity depends on shared data. So Holochain skips full self-validation for these records, only validating the basic structure of their [actions](/build/working-with-data/#entries-actions-and-records-primary-data).
+If your network needs to control who can and can't join it, you can write your DNA to require a [**membrane proof**](/resources/glossary/#membrane-proof), a small chunk of bytes that the app receives from the user at installation time and then stores on the source chain. You can then write validation rules for this record just like any other record.
 
-This creates a risk to the new agent; they may mistakenly publish malformed data and be rejected from the network. You can define a `genesis_self_check` function that checks the _content_ of genesis records before they're published. This function is limited --- it naturally doesn't have access to DHT data. But it can be a useful guard against a [membrane proof](/resources/glossary/#membrane-proof) that the participant typed or pasted incorrectly, for example.
+There's one challenge with this: validation requires access to the network (a membrane proof may reference DHT data that contains a list of public keys authorized to grant access to newcomers, for instance), but the membrane proof is written at [**genesis**](/resources/glossary/#genesis-records) time when the cell doesn't have network access yet. So Holochain can't do the usual self-validation before publishing it.
+
+This means the agent could accidentally type or paste a malformed membrane proof and be rejected from the network. To guard against this, you can define a `genesis_self_check` function that runs at genesis time and checks the content of the membrane proof before it's written.
 
 `genesis_self_check` must take a single argument of type [`GenesisSelfCheckData`](https://docs.rs/hdi/latest/hdi/prelude/type.GenesisSelfCheckData.html) and return a value of type [`ValidateCallbackResult`](https://docs.rs/hdi/latest/hdi/prelude/enum.ValidateCallbackResult.html) wrapped in an `ExternResult`.
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -94,7 +94,7 @@ Once `init` runs successfully for all coordinator zomes in a DNA, Holochain writ
 Here's an `init` callback that [links](/build/links-paths-and-anchors/) the [agent's ID](/build/identifiers/#agent) to the [DNA hash](/build/identifiers/#dna) as a sort of "I'm here" note. (It depends on a couple things being defined in your integrity zome; we'll show the integrity zome after this sample for completeness.)
 
 ```rust
-use foo_integrity::{get_participant_registration_anchor, LinkTypes};
+use foo_integrity::{get_participant_registration_anchor_hash, LinkTypes};
 use hdk::prelude::*;
 
 #[hdk_extern]
@@ -112,29 +112,18 @@ pub fn init() -> ExternResult<InitCallbackResult> {
 }
 ```
 
-Here's the `foo_integrity` zome code needed to make this work:
+Here's the `foo_integrity` zome code needed to make this work. It uses something called 'paths', which we [talk about elsewhere](/build/links-paths-and-anchors/#anchors-and-paths).
 
 ```rust
-use hdi::prelude::*
+use hdi::prelude::*;
 
 #[hdk_link_types]
 pub enum LinkTypes {
     ParticipantRegistration,
 }
 
-// This is a very simple implementation of the Anchor pattern, which you can
-// read about in https://developer.holochain.org/build/links-paths-and-anchors/
-// You don't need to tell Holochain about it with the `hdk_entry_types` macro,
-// because it never gets stored -- we only use it to calculate a hash.
-#[hdk_entry_helper]
-pub struct Anchor(pub Vec<u8>);
-
 pub fn get_participant_registration_anchor_hash() -> ExternResult<EntryHash> {
-    hash_entry(Anchor(
-        "_participants_"
-            .as_bytes()
-            .to_owned()
-    ))
+    Path(vec!["_participants_".into()]).path_entry_hash()
 }
 ```
 

--- a/src/pages/build/callbacks-and-lifecycle-hooks.md
+++ b/src/pages/build/callbacks-and-lifecycle-hooks.md
@@ -71,7 +71,7 @@ pub fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCa
 
 ## Coordinator zomes
 
-A [coordinator zome](/build/zomes/#coordinator) may define some lifecycle hooks: `init`, `post_commit`, and `recv_remote_signal`.
+A [coordinator zome](/build/zomes/#coordinator) may define some callbacks: `init`, `post_commit`, and `recv_remote_signal`.
 
 ### Define an `init` callback
 
@@ -158,7 +158,7 @@ pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
 
 <!-- TODO: move this to the signals page after it's written -->
 
-Agents in a network can send messages to each other via [remote signals](/concepts/9_signals/#remote-signals). In order to handle these signals, your coordinator zome needs to define a `recv_remote_signal` callback. Remote signals get routed from the emitting coordinator zome on the sender's machine to the same one on the receiver's machine, so there's no need for a coordinator to handle message types it doesn't know about.
+Agents in a network can send messages to each other via [remote signals](/concepts/9_signals/#remote-signals). In order to handle these signals, your coordinator zome needs to define a `recv_remote_signal` callback. Remote signals get routed from the emitting coordinator zome on the sender's machine to one of the same name on the receiver's machine.
 
 `recv_remote_signal` takes a single argument of any type you like --- if your coordinator zome deals with multiple message types, consider creating an enum for all of them. It must return an empty `ExternResult<()>`, as this callback is not called as a result of direct interaction from the local agent and has nowhere to pass a return value.
 

--- a/src/pages/build/entries.md
+++ b/src/pages/build/entries.md
@@ -43,13 +43,13 @@ pub struct Movie {
 
 This implements a host of [`TryFrom` conversions](https://docs.rs/hdi/latest/src/hdi/entry.rs.html#120-209) that your type is expected to implement, along with serialization and deserialization functions.
 
-In order to dispatch validation to the proper integrity zome, Holochain needs to know about all the entry types that your integrity zome defines. This is done by implementing a callback in your zome called `entry_defs`, but it's easier to use the [`hdi::prelude::hdk_entry_defs`](https://docs.rs/hdi/latest/hdi/prelude/attr.hdk_entry_defs.html) macro on an enum of all the entry types:
+In order to dispatch validation to the proper integrity zome, Holochain needs to know about all the entry types that your integrity zome defines. This is done by implementing a callback in your zome called `entry_defs`, but it's easier to use the [`hdi::prelude::hdk_entry_types`](https://docs.rs/hdi/latest/hdi/prelude/attr.hdk_entry_types.html) macro on an enum of all the entry types:
 
 ```rust
 use hdi::prelude::*;
 
-#[hdk_entry_defs]
-// This macro is required by hdk_entry_defs.
+#[hdk_entry_types]
+// This macro is required by hdk_entry_types.
 #[unit_enum(UnitEntryTypes)]
 enum EntryTypes {
     Director(Director),
@@ -70,7 +70,7 @@ Each variant in the enum should hold the Rust type that corresponds to it, and i
 ```rust
 use hdi::prelude::*;
 
-#[hdk_entry_defs]
+#[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 enum EntryTypes {
     Director(Director),
@@ -91,7 +91,7 @@ enum EntryTypes {
 
 Most of the time you'll want to define your create, read, update, and delete (CRUD) functions in a [**coordinator zome**](/resources/glossary/#coordinator-zome) rather than the integrity zome that defines it. This is because a coordinator zome is easier to update in the wild than an integrity zome.
 
-Create an entry by calling [`hdk::prelude::create_entry`](https://docs.rs/hdk/latest/hdk/entry/fn.create_entry.html). If you used `hdk_entry_helper` and `hdk_entry_defs` macro in your integrity zome (see [Define an entry type](#define-an-entry-type)), you can use the entry types enum you defined, and the entry will be serialized and have the correct integrity zome and entry type indexes added to it.
+Create an entry by calling [`hdk::prelude::create_entry`](https://docs.rs/hdk/latest/hdk/entry/fn.create_entry.html). If you used `hdk_entry_helper` and `hdk_entry_types` macro in your integrity zome (see [Define an entry type](#define-an-entry-type)), you can use the entry types enum you defined, and the entry will be serialized and have the correct integrity zome and entry type indexes added to it.
 
 ```rust
 use hdk::prelude::*;
@@ -113,7 +113,7 @@ let movie = Movie {
 let create_action_hash = create_entry(
     // The value you pass to `create_entry` needs a lot of traits to tell
     // Holochain which entry type from which integrity zome you're trying to
-    // create. The `hdk_entry_defs` macro will have set this up for you, so all
+    // create. The `hdk_entry_types` macro will have set this up for you, so all
     // you need to do is wrap your movie in the corresponding enum variant.
     &EntryTypes::Movie(movie),
 )?;
@@ -463,7 +463,7 @@ There are some community-maintained libraries that offer opinionated and high-le
 ## Reference
 
 * [`hdi::prelude::hdk_entry_helper`](https://docs.rs/hdi/latest/hdi/attr.hdk_entry_helper.html)
-* [`hdi::prelude::hdk_entry_defs`](https://docs.rs/hdi/latest/hdi/prelude/attr.hdk_entry_defs.html)
+* [`hdi::prelude::hdk_entry_types`](https://docs.rs/hdi/latest/hdi/prelude/attr.hdk_entry_types.html)
 * [`hdi::prelude::entry_def`](https://docs.rs/hdi/latest/hdi/prelude/entry_def/index.html)
 * [`hdk::prelude::create_entry`](https://docs.rs/hdk/latest/hdk/entry/fn.create_entry.html)
 * [`hdk::prelude::update_entry`](https://docs.rs/hdk/latest/hdk/entry/fn.update_entry.html)

--- a/src/pages/build/entries.md
+++ b/src/pages/build/entries.md
@@ -119,35 +119,58 @@ let create_action_hash = create_entry(
 )?;
 ```
 
+### Create with relaxed chain top ordering
+
+If your entry doesn't have any dependencies on other data, you can use [relaxed chain top ordering](/build/zome-functions/#relaxed-chain-top-ordering) to prevent possible transaction rollbacks (we'll let that page explain when this could happen and how to design around it).
+
+To use this feature, you'll need to use the more low-level [`create`](https://docs.rs/hdk/latest/hdk/entry/fn.create.html) host function, which requires you to build a more complex input. This example batches updates to director entries, which don't have reference other data including each other, so they're a good candidate for relaxed ordering.
+
+```rust
+use movie_integrity::{Director, EntryTypes};
+use hdk::prelude::*;
+
+let directors = vec![/* construct a vector of `Director` structs here */];
+for director in directors.iter() {
+    // To specify chain top ordering other than the default Strict, we
+    // need to use the `create` host function which requires a bit more
+    // setup.
+    let entry = EntryTypes::Director(director);
+    let ScopedEntryDefIndex {
+        zome_index,
+        zome_type: entry_def_index,
+    } = (&entry).try_into()?;
+    let visibility = EntryVisibility::from(&entry);
+    let create_input = CreateInput::new(
+        EntryDefLocation::app(zome_index, entry_def_index),
+        visibility,
+        entry.try_into()?,
+        ChainTopOrdering::Relaxed,
+    );
+    create(create_input))?;
+}
+```
+
 ### Create under the hood
 
-When the client calls a zome function that calls `create_entry`, Holochain does the following:
+When a zome function calls `create`, Holochain does the following:
 
-1. Prepare a **scratch space** for making an atomic set of changes to the source chain for the agent's cell.
-2. Build an entry creation action called [`Create`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.Create.html) that includes:
+1. Build an entry creation action called [`Create`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.Create.html) that includes:
     * the author's public key,
     * a timestamp,
     * the action's sequence in the source chain and the previous action's hash,
     * the entry type (integrity zome index and entry type index), and
     * the hash of the serialized entry data.
     <!-- * a calculated weight value for rate limiting -->
-3. Write the `Create` action and the serialized entry data to the scratch space.
-4. Return the `ActionHash` of the `Create` action to the calling zome function. (At this point, the action hasn't been persisted to the source chain.)
-5. Wait for the zome function to complete.
-6. Convert the action to DHT operations.
-7. Run the validation callback for all DHT operations.
-    * If successful, continue.
-    * If unsuccessful, return the validation error to the client instead of the zome function's return value.
-8. Compare the scratch space against the actual state of the source chain.
-    * If the source chain has diverged from the scratch space, and the write specified strict chain top ordering, the scratch space is discarded and a `HeadMoved` error is returned to the caller.
-    * If the source chain has diverged and the write specified relaxed chain top ordering, the data in the scratch space is 'rebased' on top of the new source chain state as it's being written.
-    * If the source chain has not diverged, the data in the scratch space is written to the source chain state.
-9. Return the zome function's return value to the client.
-10. In the background, publish all newly created DHT operations to their respective authority agents.
+2. Write the `Create` action and the serialized entry data to the scratch space.
+3. Return the `ActionHash` of the pending `Create` action to the calling zome function.
+
+At this point, the action hasn't been persisted to the source chain. Read the [zome function call lifecycle](/build/zome-functions/#zome-function-call-lifecycle) section to find out more about persistence.
 
 ## Update an entry
 
 Update an entry creation action by calling [`hdk::prelude::update_entry`](https://docs.rs/hdk/latest/hdk/prelude/fn.update_entry.html) with the old action hash and the new entry data:
+
+<!-- FIXME: this won't compile as written; write something that gets the old movie and its action hash from somewhere. -->
 
 ```rust
 use hdk::prelude::*;
@@ -174,28 +197,57 @@ let update_action_hash = update_entry(
 
 An [`Update` action](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.Update.html) operates on an entry creation action (either a `Create` or an `Update`), not just an entry by itself. It also doesn't remove the original data from the DHT; instead, it gets attached to both the original entry and its entry creation action. As an entry creation action itself, it references the hash of the new entry so it can be retrieved from the DHT.
 
+### Update with relaxed chain top ordering
+
+If you want to use relaxed chain top ordering, use the low-level [`update`](https://docs.rs/hdk/latest/hdk/entry/fn.update.html) instead:
+
+```rust
+use hdk::prelude::*;
+use movie_integrity::*;
+use chrono::DateTime;
+
+// A simple struct to keep a mapping to an old director action hash to new
+// entry content.
+struct OldToNewDirector {
+    old_action_hash: ActionHash,
+    new_entry: Director,
+}
+
+let old_to_new_directors = vec![
+    /* construct a vector of old director action hashes and updated content */
+];
+
+for director in old_to_new_directors.iter() {
+    // To specify chain top ordering other than the default Strict, we
+    // need to use the `create` host function which requires a bit more
+    // setup.
+    let entry = EntryTypes::Director(&director.new_entry);
+    let ScopedEntryDefIndex {
+        zome_index,
+        zome_type: entry_def_index,
+    } = (&entry).try_into()?;
+    let visibility = EntryVisibility::from(&entry);
+    let update_input: UpdateInput = {
+        original_action_address: &director.old_action_hash,
+        entry: entry.try_into()?,
+        chain_top_ordering: ChainTopOrdering::Relaxed,
+    };
+    update(update_input)?;
+}
+```
+
 ### Update under the hood
 
-Calling `update_entry` does the following:
+When a zome function calls `create`, Holochain does the following:
 
-1. Prepare a **scratch space** for making an atomic set of changes to the source chain for the agent's cell.
-2. Build an `Update` action that contains everything in a `Create` action, plus:
+1. Build an entry creation action called `Update` that contains everything in a `Create` action, plus:
     * the hash of the original action and
     * the hash of the original action's serialized entry data.
-    (Note that the entry type is automatically retrieved from the original action.)
-3. Write an `Update` action to the scratch space.
-4. Return the `ActionHash` of the `Update` action to the calling zome function. (At this point, the action hasn't been persisted to the source chain.)
-5. Wait for the zome function to complete.
-6. Convert the action to DHT operations.
-7. Run the validation callback for all DHT operations.
-    * If successful, continue.
-    * If unsuccessful, return the validation error to the client instead of the zome function's return value.
-8. Compare the scratch space against the actual state of the source chain.
-    * If the source chain has diverged from the scratch space, and the write specified strict chain top ordering, the scratch space is discarded and a `HeadMoved` error is returned to the caller.
-    * If the source chain has diverged and the write specified relaxed chain top ordering, the data in the scratch space is 'rebased' on top of the new source chain state as it's being written.
-    * If the source chain has not diverged, the data in the scratch space is written to the source chain state.
-9. Return the zome function's return value to the client.
-10. In the background, publish all newly created DHT operations to their respective authority agents.
+    (Note that the entry type and visibility are automatically retrieved from the original action.)
+2. Write the `Update` action and the serialized entry data to the scratch space.
+3. Return the `ActionHash` of the pending `Update` action to the calling zome function.
+
+As with `Create`, the action hasn't been persisted to the source chain yet. Read the [zome function call lifecycle](/build/zome-functions/#zome-function-call-lifecycle) section to find out more about persistence.
 
 ### Update patterns
 
@@ -248,24 +300,31 @@ In the future we plan to include a 'purge' functionality. This will give agents 
 
 Remember that, even once purge is implemented, it is impossible to force another person to delete data once they have seen it. Be deliberate about choosing what data becomes public in your app.
 
+### Delete with relaxed chain top ordering
+
+To delete with relaxed chain top ordering, use the low-level [`delete`](https://docs.rs/hdk/latest/hdk/entry/fn.delete.html) instead.
+
+```rust
+use hdk::prelude::*;
+
+let actions_to_delete: Vec<ActionHash> = vec![/* construct vector here */];
+for action in actions_to_delete.iter() {
+    let delete_input: DeleteInput = {
+        deletes_action_hash: action,
+        chain_top_ordering: ChainTopOrdering::Relaxed,
+    }
+    delete(delete_input)?;
+}
+```
+
 ### Delete under the hood
 
 Calling `delete_entry` does the following:
 
-1. Prepare a **scratch space** for making an atomic set of changes to the source chain for the agent's cell.
-2. Write a `Delete` action to the scratch space.
-3. Return the `ActionHash` of the `Delete` action to the calling zome function. (At this point, the action hasn't been persisted to the source chain.)
-4. Wait for the zome function to complete.
-5. Convert the action to DHT operations.
-6. Run the validation callback for all DHT operations.
-    * If successful, continue.
-    * If unsuccessful, return the validation error to the client instead of the zome function's return value.
-7. Compare the scratch space against the actual state of the source chain.
-    * If the source chain has diverged from the scratch space, and the write specified strict chain top ordering, the scratch space is discarded and a `HeadMoved` error is returned to the caller.
-    * If the source chain has diverged and the write specified relaxed chain top ordering, the data in the scratch space is 'rebased' on top of the new source chain state as it's being written.
-    * If the source chain has not diverged, the data in the scratch space is written to the source chain state.
-8. Return the zome function's return value to the client.
-9. In the background, publish all newly created DHT operations to their respective authority agents.
+1. Write a `Delete` action to the scratch space.
+2. Return the pending `ActionHash` of the `Delete` action to the calling zome function.
+
+As with `Create` and `Delete`, the action hasn't been persisted to the source chain yet. Read the [zome function call lifecycle](/build/zome-functions/#zome-function-call-lifecycle) section to find out more about persistence.
 
 ## Identifiers on the DHT
 

--- a/src/pages/build/identifiers.md
+++ b/src/pages/build/identifiers.md
@@ -226,14 +226,14 @@ Read more about [entries](/build/entries/) and [links](/build/links-paths-and-an
 There are a few important things to know about action hashes:
 
 * You can't know an action's hash until you've written the action, because the action contains the current system time at the moment of writing.
-* When you write an action, you can specify "relaxed chain top ordering". We won't go into the details here (see [the section in the Zome Functions page](/build/zome-functions/#relaxed-chain-top-ordering),but when you use it, the action hash may change after the function completes.
+* When you write an action, you can specify "relaxed chain top ordering". We won't go into the details here (see [the section in the Zome Functions page](/build/zome-functions/#relaxed-chain-top-ordering), but when you use it, the action hash may change after the function completes.
 * A function that writes actions is _atomic_, which means that all writes fail or succeed together.
 
 Because of these three things, it's unsafe to depend on the value or even existence of an action hash within the same function that writes it. Here are some 'safe usage' notes:
 
 * You may safely use the hash of an action you've just written as data in another action in the same function (e.g., in a link or an entry that contains the hash in a field), as long as you're not using relaxed chain top ordering.
 * The same is also true of action hashes in your function's return value.
-* Don't communicate the action hash with the front end, another cell, or another peer on the network via a remote function call or [signal](/concepts/9_signals/) _from within the same function that writes it_, in case the write fails. Instead, do your communicating in a follow-up step. The easiest way to do this is by implementing [a callback called `post_commit`](https://docs.rs/hdk/latest/hdk/#internal-callbacks) which receives a vector of all the actions that the function wrote.
+* Don't communicate the action hash with the front end, another cell, or another peer on the network via a remote function call or [signal](/concepts/9_signals/) _from within the same function that writes it_, in case the write fails. Instead, do your communicating in a follow-up step. The easiest way to do this is by [implementing a callback called `post_commit`](/build/callbacks-and-lifecycle-hooks/#define-a-post-commit-callback) which receives a vector of all the actions that the function wrote.
 
 <!-- TODO: write about the front end -->
 

--- a/src/pages/build/identifiers.md
+++ b/src/pages/build/identifiers.md
@@ -226,7 +226,7 @@ Read more about [entries](/build/entries/) and [links](/build/links-paths-and-an
 There are a few important things to know about action hashes:
 
 * You can't know an action's hash until you've written the action, because the action contains the current system time at the moment of writing.
-* When you write an action, you can specify "relaxed chain top ordering". We won't go into the details here, <!-- TODO: fill this in when I write about zome call lifecycles -->but when you use it, the action hash may change after the function completes.
+* When you write an action, you can specify "relaxed chain top ordering". We won't go into the details here (see [the section in the Zome Functions page](/build/zome-functions/#relaxed-chain-top-ordering),but when you use it, the action hash may change after the function completes.
 * A function that writes actions is _atomic_, which means that all writes fail or succeed together.
 
 Because of these three things, it's unsafe to depend on the value or even existence of an action hash within the same function that writes it. Here are some 'safe usage' notes:

--- a/src/pages/build/index.md
+++ b/src/pages/build/index.md
@@ -27,7 +27,7 @@ Now that you've got some basic concepts and the terms we use for them, it's time
 ::: topic-list
 * [Overview](/build/application-structure/) --- an overview of Holochain's modularity and composability units
     * [Zomes](/build/zomes/) --- integrity vs coordinator, how to structure and compile
-        * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+        * [Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/) --- writing functions that respond to events in a hApp's lifecycle
         * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
 :::
 

--- a/src/pages/build/index.md
+++ b/src/pages/build/index.md
@@ -15,6 +15,8 @@ This Build Guide organizes everything you need to know about developing Holochai
 ::: topic-list
 * [Overview](/build/application-structure/) --- an overview of Holochain's modularity and composability units
     * [Zomes](/build/zomes/) --- integrity vs coordinator, how to structure and compile
+        * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+        * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
 :::
 
 ## Working with data

--- a/src/pages/build/lifecycle-events-and-callbacks.md
+++ b/src/pages/build/lifecycle-events-and-callbacks.md
@@ -48,7 +48,7 @@ You don't need to define this callback by hand; you can let the `hdk_entry_types
 
 Holochain assumes that every participant in a network is able to self-validate all the data they create before storing it in their [source chain](/concepts/3_source_chain/) and publishing it to the [DHT](/concepts/4_dht/). But at **genesis** time, when their cell has just been instantiated but they haven't connected to other peers, they may not be able to fully validate their [**genesis records**](/concepts/3_source_chain/#source-chain-your-own-data-store) if their validity depends on shared data. So Holochain skips full self-validation for these records, only validating the basic structure of their [actions](/build/working-with-data/#entries-actions-and-records-primary-data).
 
-This creates a risk to the new participant; they may mistakenly publish malformed data and be rejected from the network. You can define a `genesis_self_check` function that checks the _content_ of genesis records before they're published. This function is limited --- it naturally doesn't have access to DHT data. But it can be a useful guard against a [membrane proof](/glossary/#membrane-proof) that the participant typed or pasted incorrectly, for example.
+This creates a risk to the new participant; they may mistakenly publish malformed data and be rejected from the network. You can define a `genesis_self_check` function that checks the _content_ of genesis records before they're published. This function is limited --- it naturally doesn't have access to DHT data. But it can be a useful guard against a [membrane proof](/resources/glossary/#membrane-proof) that the participant typed or pasted incorrectly, for example.
 
 `genesis_self_check` must take a single argument of type [`GenesisSelfCheckData`](https://docs.rs/hdi/latest/hdi/prelude/type.GenesisSelfCheckData.html) and return a value of type [`ValidateCallbackResult`](https://docs.rs/hdi/latest/hdi/prelude/enum.ValidateCallbackResult.html) wrapped in an `ExternResult`.
 
@@ -120,7 +120,7 @@ But the users are also the infrastructure, so this can create "hot spots" where 
 
 !!!
 
-This `init` callback also does something useful: it grants all other peers in the network permission to send messages to a participant's [remote signal receiver callback](#recv-remote-signal-callback).
+This `init` callback also does something useful: it grants all other peers in the network permission to send messages to a participant's [remote signal receiver callback](#define-a-recv-remote-signal-callback).
 
 ```rust
 use hdk::prelude::*;

--- a/src/pages/build/lifecycle-events-and-callbacks.md
+++ b/src/pages/build/lifecycle-events-and-callbacks.md
@@ -241,13 +241,11 @@ pub fn recv_remote_signal(payload: RemoteSignalType) -> ExternResult<()> {
 }
 
 fn get_movie_loan(action_hash: ActionHash) -> ExternResult<MovieLoan> {
-    let maybe_record = get(
+    if let Some(record) = get(
         action_hash,
         GetOptions::network()
-    )?;
-
-    if let Some(record) = maybe_record {
-        if let Some(movie_loan) = record.entry().to_app_option()? {
+    )? {
+        if let Some(movie_loan) = record.entry().to_app_option<MovieLoan>()? {
             Ok(movie_loan)
         } else {
             Err(wasm_error!("Entry wasn't a movie loan"))
@@ -269,8 +267,10 @@ pub fn update_movie(input: UpdateMovieInput) -> ExternResult<ActionHash> {
         GetOptions::network()
     )?;
     match maybe_original_record {
-        // We don't need to know the contents of the original; we just need
-        // to know it exists before trying to update it.
+        // We don't need to know the contents of the original; we just need to
+        // know it exists before trying to update it.
+        // A more robust app would at least check that the original was of the
+        // correct type.
         Some(_) => {
             update_entry(
                 input.original_hash,

--- a/src/pages/build/lifecycle-events-and-callbacks.md
+++ b/src/pages/build/lifecycle-events-and-callbacks.md
@@ -1,0 +1,221 @@
+---
+title: "Lifecycle Events and Callbacks"
+---
+
+::: intro
+A [cell](/concepts/2_application_architecture/#cell) can respond to various events in the life of a hApp by defining specially named **lifecycle callbacks**. This lets back-end code define and validate data, perform initialization tasks, respond to [remote signals](/concepts/9_signals), and follow up after successful writes.
+:::
+
+All of the lifecycle callbacks must follow the [pattern for public functions](/build/zomes/#define-a-function) on the Zomes page. They must also have the specific input argument and return value types described below.
+
+## Integrity zomes
+
+Your [integrity zome](/build/zomes/#integrity) must define two callbacks, `validate` and `entry_defs`, and it may define an optional callback, `genesis_self_check`. All of these functions **cannot have side effects**; any attempt to write data will fail. They also cannot access data that changes over time or across participants, such as the cell's [agent ID](/build/identifiers/#agent) or a collection of [links](/build/links-paths-and-anchors/) in the [DHT](/concepts/4_dht).
+
+
+### Define a `validate` callback
+
+In order to validate your data you'll need to define a `validate` callback. It must take a single argument of type [`Op`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/op/enum.Op.html) and return a value of type [`ValidateCallbackResult`](https://docs.rs/hdi/latest/hdi/prelude/enum.ValidateCallbackResult.html) wrapped in an `ExternResult`.
+
+The `validate` callback is called at two times:
+
+1. On an agent's device, when they try to author an [action](/build/working-with-data/#entries-actions-and-records-primary-data), and
+2. On a peer's device, when they receive a [DHT operation](/concepts/4_dht/#a-cloud-of-witnesses) to store and serve as part of the shared database.
+
+The nature of validation is out of scope for this page (we'll write a page on it soon), but here's a very basic example of a validation callback that approves everything: <!-- TODO: remove this example when the validation page is written -->
+
+```rust
+#[hdk_extern]
+pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
+    Ok(Valid)
+}
+```
+
+And here's an example of one that rejects everything. You'll note that the outer result is `Ok`; you should generally reserve `Err` for unexpected failures such as inability to deserialize data. However, Holochain will treat both `Ok(Invalid)` and `Err` as invalid operations that should be rejected.
+
+```rust
+#[hdk_extern]
+pub fn validate(_: Op) -> ExternResult<ValidateCallbackResult> {
+    Ok(Invalid("I reject everything"))
+}
+```
+
+### Define an `entry_defs` callback
+
+You don't need to define this callback by hand; you can let the `hdk_entry_types` macro do it for you. Read the [Define an entry type section](/build/entries/#define-an-entry-type) to find out how.
+
+### Define a `genesis_self_check` callback
+
+Holochain assumes that every participant in a network is able to self-validate all the data they create before storing it in their [source chain](/concepts/3_source_chain/) and publishing it to the [DHT](/concepts/4_dht/). But at **genesis** time, when their cell has just been instantiated but they haven't connected to other peers, they may not be able to fully validate their [**genesis records**](/concepts/3_source_chain/#source-chain-your-own-data-store) if their validity depends on shared data. So Holochain skips full self-validation for these records, only validating the basic structure of their [actions](/build/working-with-data/#entries-actions-and-records-primary-data).
+
+This creates a risk to the new participant; they may mistakenly publish malformed data and be rejected from the network. You can define a `genesis_self_check` function that checks the _content_ of genesis records before they're published. This function is limited --- it naturally doesn't have access to DHT data. But it can be a useful guard against a [membrane proof](/glossary/#membrane-proof) that the participant typed or pasted incorrectly, for example.
+
+`genesis_self_check` must take a single argument of type [`GenesisSelfCheckData`](https://docs.rs/hdi/latest/hdi/prelude/type.GenesisSelfCheckData.html) and return a value of type [`ValidateCallbackResult`](https://docs.rs/hdi/latest/hdi/prelude/enum.ValidateCallbackResult.html) wrapped in an `ExternResult`.
+
+Here's an example that checks that the membrane proof exists and is the right length: <!-- TODO: move this to the validation page too -->
+
+```rust
+use hdi::prelude::{GenesisSelfCheckData, hdk_extern, ValidateCallbackResult};
+
+#[hdk_extern]
+pub fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
+    if let Some(membrane_proof) = data.membrane_proof {
+        if membrane_proof.bytes().len() == 32 {
+            Ok(Valid)
+        }
+        Ok(Invalid("Membrane proof is not the right length. Please check it and enter it again."))
+    }
+    Ok(Invalid("This network needs a membrane proof to join."))
+}
+```
+
+## Coordinator zomes
+
+A [coordinator zome](/build/zomes/#coordinator) may define some optional lifecycle callbacks: `init`, `post_commit`, and `recv_remote_signal`.
+
+### Define an `init` callback
+
+If you want to run setup tasks when the cell is being initialized, define a callback function called `init` in your coordinator zome. Holochain will call it after a cell has been created for the DNA containing the zome, following the order of coordinator zomes in the DNA's manifest, calling each zome's `init` in serial rather than calling them all in parallel.
+
+!!! info `init` isn't called immediately on cell instantiation
+
+This callback is called 'lazily'; that is, it's not called _immediately_ after the cell has been instantiated. Instead, Holochain waits until the first zome function call is made, then calls `init` before calling the zome function.
+
+This gives a participant's Holochain runtime a little bit of time to connect to other peers, which makes various things you might want to do in `init` more likely to succeed if they depend on data in the DHT.
+
+You can force `init` to run eagerly by calling it as if it were a normal zome function. _Note that you can only do this in Holochain 0.5 and newer._
+
+!!!
+
+Once `init` runs successfully for all coordinator zomes in a DNA, Holochain writes an [`InitZomesComplete` action](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.InitZomesComplete.html). That ensures that this callback isn't called again.
+
+`init` must take an empty `()` input argument and return an [`InitCallbackResult`](https://docs.rs/hdk/latest/hdk/prelude/enum.InitCallbackResult.html) wrapped in an `ExternResult`. All zomes' `init` callbacks in a DNA must return a success result in order for cell initialization to succeed; otherwise any data written in these callbacks, along with the `InitZomesComplete` action, will be rolled back. _If any zome's init callback returns an `InitCallbackResult::Fail`, initialization will fail._ Otherwise, if any init callback returns an `InitCallbackResult::UnresolvedDependencies`, initialization will be retried at the next zome call attempt.
+
+Here's an `init` callback that [links](/build/links-paths-and-anchors/) the [agent's ID](/build/identifiers/#agent) to the [DNA hash](/build/identifiers/#dna) as a sort of "I'm here" note. (It assumes that you've written an integrity zome called `foo_integrity` that defines one type of link called `ParticipantRegistration`.)
+
+```rust
+use foo_integrity::LinkTypes;
+use hdk::prelude::*;
+
+#[hdk_extern]
+pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    let DnaInfoV2 { hash: dna_hash } = dna_info()?;
+    let AgentInfo { agent_latest_pubkey: my_pubkey } = agent_info()?;
+    create_link(
+        dna_hash,
+        my_pubkey,
+        LinkTypes::ParticipantRegistration,
+        ()
+    )?;
+
+    Ok(InitCallbackResult::Pass)
+}
+```
+
+!!! info Why link the agent key to a well-known hash?
+
+Because there's no single source of truth in a Holochain network, it's impossible to get the full list of peers who have joined it. The above pattern is an easy way for newcomers to register themselves as active participants so others can find them.
+
+But the users are also the infrastructure, so this can create "hot spots" where a set of peers --- the ones responsible for storing the base address for all those links --- carry an outsized burden compared to other peers. Read the [anchors and paths section under Links, Paths, and Anchors](/build/links-paths-and-anchors/#anchors-and-paths) for more info.
+
+!!!
+
+This `init` callback also does something useful: it grants all other peers in the network permission to send messages to a participant's [remote signal receiver callback](#recv-remote-signal-callback).
+
+```rust
+use hdk::prelude::*;
+
+#[hdk_extern]
+pub fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "recv_remote_signal".into()));
+    create_cap_grant(CapGrantEntry {
+        tag: "".into(),
+        access: CapAccess::Unrestricted,
+        functions: GrantedFunctions::Listed(fns),
+    })?;
+
+    Ok(InitCallbackResult::Pass)
+}
+```
+
+### Define a `post_commit` callback
+
+After a zome function call completes, any actions that it created are validated, then written to the cell's source chain if all actions pass validation. While the function is running, nothing has been stored even if [CRUD](/build/working-with-data/#adding-and-modifying-data) function calls return `Ok`. (Read more about the [atomic, transactional nature](/build/zome-functions/#atomic-transactional-commits) of writes in a zome function call.)
+
+If you need to do any follow-up after a successful write beyond returning the function's return value to the caller, it's safer to do this in a lifecycle callback called `post_commit`, which is called after Holochain's [call-zome workflow](/build/zome-functions/#zome-function-call-lifecycle) successfully writes its actions to the source chain. (Function calls that don't write data won't trigger this event.)
+
+`post_commit` must take a single argument of type <code>Vec&lt;<a href="https://docs.rs/hdk/latest/hdk/prelude/type.SignedActionHashed.html">SignedActionHashed</a>&gt;</code>, which contains all the actions the function call wrote, and it must return an empty `ExternResult<()>`. This callback must not write any data, but it may call other zome functions in the same cell or any other local or remote cell, and it may
+
+Here's an example that uses `post_commit` to tell the original author of a `Movie` entry that someone has edited it. It uses the integrity zome examples from [Entries](/build/entries/).
+
+```rust
+use movie_integrity::{EntryTypes, Movie};
+use hdk::*;
+
+struct UpdateMovieInput {
+    original_hash: ActionHash,
+    data: Movie,
+}
+
+#[hdk_extern]
+pub fn update_movie(input: UpdateMovieInput) -> ExternResult<ActionHash> {
+
+}
+```
+
+### Define a `recv_remote_signal` callback
+
+<!-- TODO: move this to the signals page after it's written -->
+
+Peers in a network can send messages to each other via [remote signals](/concepts/9_signals/#remote-signals). In order to handle these signals, your coordinator zome needs to define a `recv_remote_signal` callback. Remote signals get routed from the emitting coordinator zome on Alice's machine to the same one on Bob's machine, so there's no need for a coordinator to handle message types it doesn't know about.
+
+`recv_remote_signal` takes a single argument of any type you like --- if your coordinator zome deals with multiple message types, consider creating an enum for all of them. It must return an empty `ExternResult<()>`, as this callback is not called as a result of direct interaction from the local agent and has nowhere to pass a return value.
+
+This zome function and remote signal receiver callback implement a "heartbeat" to let all network participants know who's currently online. It assumes that you'll combine the two `init` callback examples in the previous section, which set up the necessary links and permissions to make this work.
+
+```rust
+use foo_integrity::LinkTypes;
+use hdk::prelude::*;
+
+// We're using this type for both remote signals to other peers and local
+// signals to the UI.
+enum SignalType {
+    Heartbeat(AgentPubKey),
+}
+
+// My UI calls this function at regular intervals to let other participants
+// know I'm online.
+#[hdk_extern]
+pub fn heartbeat(_: ()) -> ExternResult<()> {
+    // Get all the registered participants from the DNA hash.
+    let DnaInfoV2 { hash: dna_hash } = dna_info()?;
+    let other_participants_keys = get_links(
+        GetLinksInputBuilder::try_new(
+            dna_hash,
+            LinkTypes::ParticipantRegistration
+        )?
+            .get_options(GetStrategy::Network)
+            .build()
+    )?
+        .filter_map(|l| l.target.into_agent_pub_key());
+
+    // Now send a heartbeat message to each of them.
+    // Holochain will send them in parallel and won't return an error for any
+    // failure.
+    let AgentInfo { agent_latest_pubkey: my_pubkey } = agent_info()?;
+    send_remote_signal(
+        SignalType::Heartbeat(my_pubkey),
+        other_participants_keys
+    )
+}
+
+#[hdk_extern]
+pub fn recv_remote_signal(payload: SignalType) -> ExternResult<()> {
+    match payload {
+        // Pass the heartbeat along to my UI so it can update the other
+        // peer's online status.
+        SignalType::Heartbeat(peer_pubkey) => emit_signal(payload)
+    }
+}
+```

--- a/src/pages/build/links-paths-and-anchors.md
+++ b/src/pages/build/links-paths-and-anchors.md
@@ -73,6 +73,21 @@ let create_link_action_hash = create_link(
 
 Links can't be updated; they can only be created or deleted. Multiple links with the same base, target, type, and tag can be created, and they'll be considered separate links for retrieval and deletion purposes.
 
+### Creating a link, under the hood
+
+When a zome function calls `create_link`, Holochain does the following:
+
+1. Build an action called [`CreateLink`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.CreateLink.html) that includes:
+    * the author's public key,
+    * a timestamp,
+    * the action's sequence in the source chain and the previous action's hash, and
+    * the link type, base, target, and tag.
+    <!-- * a calculated weight value for rate limiting -->
+2. Write the action to the scratch space.
+3. Return the `ActionHash` of the pending action to the calling zome function.
+
+At this point, the action hasn't been persisted to the source chain. Read the [zome function call lifecycle](/build/zome-functions/#zome-function-call-lifecycle) section to find out more about persistence.
+
 ## Delete a link
 
 Delete a link by calling [`hdk::prelude::delete_link`](https://docs.rs/hdk/latest/hdk/link/fn.delete_link.html) with the create-link action's hash.
@@ -86,6 +101,21 @@ let delete_link_action_hash = delete_link(
 ```
 
 A link is considered ["dead"](/build/working-with-data/#deleted-dead-data) (deleted but retrievable if asked for explicitly) once its creation action has at least one delete-link action associated with it. As with entries, dead links can still be retrieved with [`hdk::prelude::get_details`](https://docs.rs/hdk/latest/hdk/prelude/fn.get_details.html) or [`hdk::prelude::get_link_details`](https://docs.rs/hdk/latest/hdk/link/fn.get_link_details.html) (see next section).
+
+### Deleting a link, under the hood
+
+When a zome function calls `delete_link`, Holochain does the following:
+
+1. Build an action called [`DeleteLink`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/action/struct.DeleteLink.html) that includes:
+    * the author's public key,
+    * a timestamp,
+    * the action's sequence in the source chain and the previous action's hash, and
+    * the link type, base, target, and tag.
+    <!-- * a calculated weight value for rate limiting -->
+2. Write the action to the scratch space.
+3. Return the `ActionHash` of the pending action to the calling zome function.
+
+At this point, the action hasn't been persisted to the source chain. Read the [zome function call lifecycle](/build/zome-functions/#zome-function-call-lifecycle) section to find out more about persistence.
 
 ## Retrieve links
 

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -3,7 +3,7 @@ title: "Zome Functions"
 ---
 
 ::: intro
-Besides [lifecycle callbacks](/build/lifecycle-callbacks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
+Besides [lifecycle callbacks](/build/lifecycle-events-and-callbacks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
 :::
 
 As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [lifecycle callbacks](/build/lifecycle-events-and-callbacks/), and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -3,10 +3,10 @@ title: "Zome Functions"
 ---
 
 ::: intro
-Besides [lifecycle hooks](/build/callbacks-and-lifecycle-hooks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
+Besides special [callbacks](/build/callbacks-and-lifecycle-hooks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
 :::
 
-As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [lifecycle hooks](/build/callbacks-and-lifecycle-hooks/), and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.
+As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [callbacks](/build/callbacks-and-lifecycle-hooks/) with special purposes, and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.
 
 Holochain sandboxes your zome, acting as an intermediary between it and the user's storage and UI at the local level, and between it and other peers at the network level.
 

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -17,7 +17,7 @@ A zome function is a public function that's tagged with the [`hdk_extern`](https
 Here's a simple example of a zome function that takes a name and returns a greeting:
 
 ```rust
-use hdk::prelude::{hdk_extern, ExternResult};
+use hdk::prelude::*;
 
 #[hdk_extern]
 pub fn say_hello(name: String) -> ExternResult<String> {

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -3,10 +3,10 @@ title: "Zome Functions"
 ---
 
 ::: intro
-Besides [lifecycle callbacks](/build/lifecycle-events-and-callbacks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
+Besides [lifecycle hooks](/build/callbacks-and-lifecycle-hooks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
 :::
 
-As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [lifecycle callbacks](/build/lifecycle-events-and-callbacks/), and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.
+As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [lifecycle hooks](/build/callbacks-and-lifecycle-hooks/), and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.
 
 Holochain sandboxes your zome, acting as an intermediary between it and the user's storage and UI at the local level, and between it and other peers at the network level.
 
@@ -33,7 +33,7 @@ A zome function call's writes are _atomic_ and _transactional_; that is, **all t
 
 Zome function calls, and their transactions, can also run in parallel. A zome call transaction has one big difference from traditional database transactions: if one transaction begins, then another transaction begins and commits before the first transaction finishes, **the first transaction will roll back** and return a 'chain head moved' error to the caller.
 
-The possibility of a rollback means that any follow-up tasks with written data should happen in a [`post_commit` callback](/build/lifecycle-events-and-callbacks/#define-a-post-commit-callback).
+The possibility of a rollback means that any follow-up tasks with written data should happen in a [`post_commit` callback](/build/callbacks-and-lifecycle-hooks/#define-a-post-commit-callback).
 
 ### Relaxed chain top ordering
 
@@ -80,7 +80,7 @@ Here's how the **call-zome workflow** handles a zome function call:
         * If at least one wasn't, return a 'chain head moved' error to the caller.
 8. Write the new actions to the source chain and store their corresponding DHT operations in the local DHT store.
 9. Trigger the **publish** workflow in a separate thread, which will try to share the DHT operations with network peers.
-10. Trigger the **post-commit** workflow in a separate thread, which will look for a [`post_commit` callback](/build/lifecycle-events-and-callbacks/#define-a-post-commit-callback) in the same zome as the called function, and pass the new actions to it.
+10. Trigger the **post-commit** workflow in a separate thread, which will look for a [`post_commit` callback](/build/callbacks-and-lifecycle-hooks/#define-a-post-commit-callback) in the same zome as the called function, and pass the new actions to it.
 11. Return the zome function's return value to the caller.
 
 ## References
@@ -93,5 +93,5 @@ Here's how the **call-zome workflow** handles a zome function call:
 
 * [Core Concepts: Application Architecture](/concepts/2_application_architecture/)
 * [Build Guide: Zomes](/build/zomes/)
-* [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
+* [Build Guide: Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/)
 * [Build Guide: Entries: Create with relaxed chain top ordering](/build/entries/#create-with-relaxed-chain-top-ordering)

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -1,0 +1,97 @@
+---
+title: "Zome Functions"
+---
+
+::: intro
+Besides [lifecycle callbacks](/build/lifecycle-callbacks), a zome defines public functions that acts as its API. These functions can read and write data, manage permissions, send signals, and call functions in other cells in the same Holochain instance or to remote peers in the same network.
+:::
+
+As we touched on in the [Zomes page](/build/zomes/#how-a-zome-is-structured), a zome is just a WebAssembly module with some public functions. These functions have access to Holochain's host API. Some of them are [lifecycle callbacks](/build/lifecycle-events-and-callbacks/), and others are functions you create yourself to serve as your zome's API. This second kind of function is what we'll talk about in this page.
+
+Holochain sandboxes your zome, acting as an intermediary between it and the user's storage and UI at the local level, and between it and other peers at the network level.
+
+## Define a zome function
+
+A zome function is a public function that's tagged with the [`hdk_extern`](https://docs.rs/hdk/latest/hdk/prelude/attr.hdk_extern.html) procedural macro. It must follow the constraints described in the [Define a function section in the Zomes page](/build/zomes/#define-a-function).
+
+Here's a simple example of a zome function that takes a name and returns a greeting:
+
+```rust
+use hdk::prelude::{hdk_extern, ExternResult};
+
+#[hdk_extern]
+pub fn say_hello(name: String) -> ExternResult<String> {
+    Ok(format!("Hello {}!", name))
+}
+```
+
+## Atomic, transactional commits
+
+When a zome function wants to persist data, it stores it as [actions](/build/working-with-data/#entries-actions-and-records-primary-data) in the cell's [source chain](/build/working-with-data/#individual-state-histories-as-public-records). At the beginning of each call, Holochain prepares a **scratch space** containing the current source state, and all source chain read/write functions work on this scratch space rather than live source chain data.
+
+A zome function call's writes are _atomic_ and _transactional_; that is, **all the writes succeed or fail together**. If any of the actions fail validation, the scratch space is discarded and the validation error is returned to the caller.
+
+Zome function calls, and their transactions, can also run in parallel. A zome call transaction has one big difference from traditional database transactions: if one transaction begins, then another transaction begins and commits before the first transaction finishes, **the first transaction will roll back** and return a 'chain head moved' error to the caller.
+
+The possibility of a rollback means that any follow-up tasks with written data should happen in a [`post_commit` callback](/build/lifecycle-events-and-callbacks/#define-a-post-commit-callback).
+
+### Relaxed chain top ordering
+
+As you saw in step 7 above, parallel transactions can cause each other to fail and roll back. In limited cases, you can write all your data in a single transaction with **relaxed chain top ordering** to prevent rollbacks. It tries to 'rebase' all the actions in the transaction onto the _new live state_ of the source chain if another function call changed the source chain state while the function was running.
+
+You have to be careful, though, because the action hashes you get back from the host when you attempt to write data will be different after the rebase. If you want to try using relaxed chain top ordering, here are some guidelines:
+
+* Actions within the transaction shouldn't depend on each other's hashes; for instance, the hash of action 1 shouldn't be used in the data of action 2.
+* Actions shouldn't depend too exactly on the snapshotted source chain state; that is, action 1 shouldn't fail validation if the action immediately before it is different from what's expected.
+
+You can find an example of writing data using relaxed chain top ordering on the [Entries page](/build/entries/#create-with-relaxed-chain-top-ordering).
+
+## Zome function call lifecycle
+
+A zome function call lifecycle begins when an external caller tries to call one of the functions in a zome of an active cell. The caller can be any one of:
+
+* Another peer in the [same DNA network](/build/application-structure/#dna),
+* A client such as a UI, running on the same machine as the participant's Holochain instance,
+* Another cell in the same Holochain instance, or
+* The same cell.
+
+The caller must call the function by cell ID and zome name, and it must supply a valid [**capability claim**](/concepts/8_calls_capabilities/) in order to call the zome function.
+
+Here's how the **call-zome workflow** handles a zome function call:
+
+<!-- TODO: Make this into a sequence diagram -->
+
+1. Check that the supplied capability claim matches a currently active capability grant. If it doesn't, return an unauthorized error to the caller.
+3. Create a 'scratch space' containing a snapshot of the current state of the cell's source chain.
+4. Dispatch the zome call payload to the correct cell/zome/function. At this point execution passes to the zome.
+    1. The [HDK](https://crates.io/crates/hdk) attempts to deserialize the payload into the expected type.
+    2. If deserialization fails, return an [`ExternResult::Err`](https://docs.rs/hdk/latest/hdk/map_extern/type.ExternResult.html#variant.Err) containing details of the error. Execution passes back to the call-zome workflow, which passes the error to the caller.
+    3. The HDK passes the deserialized payload to the zome function. The function runs, calling the host API as needed. **Any functions that attempt to read from or write to the cell's source chain operate on the snapshot, not the source chain's current state.**
+    4. The function returns a return value, and the HDK serializes it and passes it back to the call-zome workflow.
+5. If there are no new writes in the scratch space, return the zome function's return value to the caller.
+6. Generate [DHT operations](https://docs.rs/hdi/latest/hdi/prelude/enum.Op.html) from each action and dispatch them to the appropriate validation callbacks in the DNA's [integrity zome](/build/application-structure/#zome)(s).
+    * If the action is a [CRUD action](/build/working-with-data/#crud-metadata-graph) for application data, only the validation callback for the integrity zome that defined the data type is called.
+    * If the action is a system action, or a CRUD action for a system entry type, the validation callbacks in all integrity zomes in the DNA are called.
+
+    If validation fails for _any_ of the operations, return the first <!-- FIXME: last? that seems to be what the `fold` does --> validation error.
+7. Check whether the source chain's snapshot in the scratch space is older than the live source chain state, which happens if another call-zome workflow started and completed while this workflow was running.
+    * If the snapshot is older, check if all the actions were written with relaxed chain top ordering.
+        * If they were, create a fresh scratch space with a snapshot of the _new_ source chain state, rebase all of the new actions on top of it, and return to step 6.
+        * If at least one wasn't, return a 'chain head moved' error to the caller.
+8. Write the new actions to the source chain and store their corresponding DHT operations in the local DHT store.
+9. Trigger the **publish** workflow in a separate thread, which will try to share the DHT operations with network peers.
+10. Trigger the **post-commit** workflow in a separate thread, which will look for a [`post_commit` callback](/build/lifecycle-events-and-callbacks/#define-a-post-commit-callback) in the same zome as the called function, and pass the new actions to it.
+11. Return the zome function's return value to the caller.
+
+## References
+
+* [`hdk_derive::hdk_extern`](https://docs.rs/hdk_derive/latest/hdk_derive/attr.hdk_extern.html)
+* [`hdi::map_extern::ExternResult`](https://docs.rs/hdi/latest/hdi/map_extern/type.ExternResult.html)
+* [`holochain_integrity_types::op::Op`](https://docs.rs/holochain_integrity_types/latest/holochain_integrity_types/op/enum.Op.html)
+
+## Further reading
+
+* [Core Concepts: Application Architecture](/concepts/2_application_architecture/)
+* [Build Guide: Zomes](/build/zomes/)
+* [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
+* [Build Guide: Entries: Create with relaxed chain top ordering](/build/entries/#create-with-relaxed-chain-top-ordering)

--- a/src/pages/build/zome-functions.md
+++ b/src/pages/build/zome-functions.md
@@ -92,6 +92,7 @@ Here's how the **call-zome workflow** handles a zome function call:
 ## Further reading
 
 * [Core Concepts: Application Architecture](/concepts/2_application_architecture/)
+* [Core Concepts: Calls and Capabilities](/concepts/8_calls_capabilities/)
 * [Build Guide: Zomes](/build/zomes/)
 * [Build Guide: Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/)
 * [Build Guide: Entries: Create with relaxed chain top ordering](/build/entries/#create-with-relaxed-chain-top-ordering)

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -30,7 +30,7 @@ Because these callbacks only need a small portion of Holochain's functionality, 
 
 Your integrity zome tells Holochain about the types of [entries](/build/entries/) and [links](/build/links-paths-and-anchors/) it defines with macros called [`hdk_entry_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_entry_types.html) and [`hdk_link_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_link_types.html) added to enums of all the entry and link types. These create lifecycle callbacks that are run at DNA install time and give Holochain the info it needs. Read more in [Define an entry type](/build/entries/#define-an-entry-type) and [Define a link type](/build/links-paths-and-anchors/#define-a-link-type).
 
-Finally, your integrity zome defines [validation callbacks](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) that check for correctness of data and actions. Holochain runs this on an agent's own device when they attempt to author data, and on other peers' devices when they're asked to store and serve data authored by others.
+Finally, your integrity zome defines validation callbacks <!-- TODO: uncomment once lifecycle events PR is merged [validation callbacks](/build/lifecycle-events-and-callbacks/#define-a-validate-callback)--> that check for correctness of data and actions. Holochain runs this on an agent's own device when they attempt to author data, and on other peers' devices when they're asked to store and serve data authored by others.
 
 #### Create an integrity zome
 

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -50,7 +50,7 @@ Then add some necessary dependencies to your new `Cargo.toml` file:
 +serde = "1.0"
 ```
 
-At the very minimum, make sure your code exposes a [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) and [defines some entry types](/build/entries/#define-an-entry-type).
+At the very minimum, make sure your code exposes a `validate` callback <!-- TODO: uncomment once lifecycle events PR is merged [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback)--> and [defines some entry types](/build/entries/#define-an-entry-type).
 
 Compile your zome using `cargo`:
 
@@ -60,7 +60,7 @@ cargo build --release --target wasm32-unknown-unknown
 
 ### Coordinator
 
-Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional, specially named [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes), you can also write your own **zome functions** that serve as your zome's API.
+Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional, specially named lifecycle callbacks <!-- TODO: uncomment once lifecycle events PR is merged [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes)-->, you can also write your own **zome functions** that serve as your zome's API.
 
 #### Create a coordinator zome
 
@@ -138,7 +138,7 @@ pub fn check_age_for_18a_movie(age: u32) -> ExternResult<()> {
 
 ## Further reading
 
-* [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
+<!-- TODO: uncomment after lifecycle events PR is merged * [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)-->
 <!-- TODO: uncomment after zome functions PR is merged * [Build Guide: Zome Functions](/build/zome-functions/)-->
 * [WebAssembly](https://webassembly.org/)
 * [serde](https://serde.rs/)

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -6,7 +6,7 @@ title: "Zomes"
 ### In this section {data-no-toc}
 
 * Zomes (this page)
-    * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+    * [Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/) --- writing functions that respond to events in a hApp's lifecycle
     * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
 :::
 
@@ -16,7 +16,7 @@ A **zome** (short for chromosome) is a module of executable code within a [**DNA
 
 ## How a zome is structured
 
-A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) calls these functions at different points in the application's lifetime. Some functions have special names and serve as [**callbacks**](/build/lifecycle-events-and-callbacks/) that are called by the Holochain system. Others are ones you define yourself, and they become your zome's API that external processes such as a UI can call.
+A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) calls these functions at different points in the application's lifetime. Some functions have special names and serve as [**callbacks**](/build/callbacks-and-lifecycle-hooks/) that are called by the Holochain system. Others are ones you define yourself, and they become your zome's API that external processes such as a UI can call.
 
 ## How a zome is written
 
@@ -40,7 +40,7 @@ When you're writing an integrity zome, use the smaller [`hdi`](https://crates.io
 
 Your integrity zome tells Holochain about the types of [entries](/build/entries/) and [links](/build/links-paths-and-anchors/) it defines with macros called [`hdk_entry_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_entry_types.html) and [`hdk_link_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_link_types.html) added to enums of all the entry and link types. These create callbacks that are run at DNA install time. Read more in [Define an entry type](/build/entries/#define-an-entry-type) and [Define a link type](/build/links-paths-and-anchors/#define-a-link-type).
 
-Finally, your integrity zome defines [**validation callbacks**](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) that check for correctness of data and actions. Holochain runs this on an agent's own device when they try to author data, and when they're asked to store and serve data authored by others.
+Finally, your integrity zome defines [**validation callbacks**](/build/callbacks-and-lifecycle-hooks/#define-a-validate-callback) that check for correctness of data and actions. Holochain runs this on an agent's own device when they try to author data, and when they're asked to store and serve data authored by others.
 
 #### Create an integrity zome
 
@@ -60,7 +60,7 @@ Then add some necessary dependencies to your new `Cargo.toml` file:
 +serde = "1.0"
 ```
 
-Now you can write a [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) and [define some entry types](/build/entries/#define-an-entry-type).
+Now you can write a [`validate` callback](/build/callbacks-and-lifecycle-hooks/#define-a-validate-callback) and [define some entry types](/build/entries/#define-an-entry-type).
 
 When you've written some code, compile your zome using `cargo`:
 
@@ -70,7 +70,7 @@ cargo build --release --target wasm32-unknown-unknown
 
 ### Coordinator
 
-Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional lifecycle callbacks [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes), you'll also write your own **zome functions** that serve as your zome's API.
+Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional lifecycle hooks [lifecycle hooks](/build/callbacks-and-lifecycle-hooks/#coordinator-zomes), you'll also write your own **zome functions** that serve as your zome's API.
 
 #### Create a coordinator zome
 
@@ -143,7 +143,7 @@ pub fn check_age_for_18a_movie(age: u32) -> ExternResult<()> {
 
 ## Further reading
 
-* [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
+* [Build Guide: Lifecycle Events and Callbacks](/build/callbacks-and-lifecycle-hooks/)
 * [Build Guide: Zome Functions](/build/zome-functions/)
 * [WebAssembly](https://webassembly.org/)
 * [serde](https://serde.rs/)

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -16,7 +16,7 @@ A **zome** (short for chromosome) is a module of executable code within a [**DNA
 
 ## How a zome is structured
 
-A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) knows about these functions and calls them at different points in the application's lifetime. Some functions have special names and are called **lifecycle callbacks**<!-- TODO uncomment when lifecycle callbacks PR is merged [lifecycle callbacks](/build/lifecycle-events-and-callbacks/)-->, and you can also define arbitrarily named functions of your own to serve as your zome's API.
+A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) knows about these functions and calls them at different points in the application's lifetime. Some functions have special names and are called [lifecycle callbacks](/build/lifecycle-events-and-callbacks/), and you can also define arbitrarily named functions of your own to serve as your zome's API.
 
 For Rust developers, we've created an SDK called the [Holochain Development Kit (HDK)](https://crates.io/crates/hdk/). It lets you define functions, exchange data with the host (the Holochain VM), and access all of the host's functionality.
 
@@ -38,7 +38,7 @@ Because these callbacks only need a small portion of Holochain's functionality, 
 
 Your integrity zome tells Holochain about the types of [entries](/build/entries/) and [links](/build/links-paths-and-anchors/) it defines with macros called [`hdk_entry_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_entry_types.html) and [`hdk_link_types`](https://docs.rs/hdi/latest/hdi/attr.hdk_link_types.html) added to enums of all the entry and link types. These create lifecycle callbacks that are run at DNA install time and give Holochain the info it needs. Read more in [Define an entry type](/build/entries/#define-an-entry-type) and [Define a link type](/build/links-paths-and-anchors/#define-a-link-type).
 
-Finally, your integrity zome defines validation callbacks <!-- TODO: uncomment once lifecycle events PR is merged [validation callbacks](/build/lifecycle-events-and-callbacks/#define-a-validate-callback)--> that check for correctness of data and actions. Holochain runs this on an agent's own device when they attempt to author data, and on other peers' devices when they're asked to store and serve data authored by others.
+Finally, your integrity zome defines [validation callbacks](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) that check for correctness of data and actions. Holochain runs this on an agent's own device when they attempt to author data, and on other peers' devices when they're asked to store and serve data authored by others.
 
 #### Create an integrity zome
 
@@ -58,7 +58,7 @@ Then add some necessary dependencies to your new `Cargo.toml` file:
 +serde = "1.0"
 ```
 
-At the very minimum, make sure your code exposes a `validate` callback <!-- TODO: uncomment once lifecycle events PR is merged [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback)--> and [defines some entry types](/build/entries/#define-an-entry-type).
+At the very minimum, make sure your code exposes a [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) and [defines some entry types](/build/entries/#define-an-entry-type).
 
 Compile your zome using `cargo`:
 
@@ -68,7 +68,7 @@ cargo build --release --target wasm32-unknown-unknown
 
 ### Coordinator
 
-Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional, specially named lifecycle callbacks <!-- TODO: uncomment once lifecycle events PR is merged [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes)-->, you can also write your own **zome functions** that serve as your zome's API.
+Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional, specially named [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes), you can also write your own **zome functions** that serve as your zome's API.
 
 #### Create a coordinator zome
 
@@ -146,7 +146,7 @@ pub fn check_age_for_18a_movie(age: u32) -> ExternResult<()> {
 
 ## Further reading
 
-<!-- TODO: uncomment after lifecycle events PR is merged * [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)-->
-<!-- TODO: uncomment after zome functions PR is merged * [Build Guide: Zome Functions](/build/zome-functions/)-->
+* [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
+* [Build Guide: Zome Functions](/build/zome-functions/)
 * [WebAssembly](https://webassembly.org/)
 * [serde](https://serde.rs/)

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -2,6 +2,14 @@
 title: "Zomes"
 ---
 
+::: topic-list
+### In this section {data-no-toc}
+
+* Zomes (this page)
+    * [Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/) --- writing functions that respond to events in a hApp's lifecycle
+    * [Zome Functions](/build/zome-functions/) --- writing your hApp's back-end API
+:::
+
 ::: intro
 A **zome** (short for chromosome) is a module of executable code within a [**DNA**](/resources/glossary/#dna). It's the smallest unit of modularity in a Holochain application.
 :::

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -3,12 +3,12 @@ title: "Zomes"
 ---
 
 ::: intro
-A **zome** (short for chromosome) is a module of executable code within a [**DNA**](/glossary/#dna). It's the smallest unit of modularity in a Holochain application.
+A **zome** (short for chromosome) is a module of executable code within a [**DNA**](/resources/glossary/#dna). It's the smallest unit of modularity in a Holochain application.
 :::
 
 ## How a zome is structured
 
-A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) knows about these functions and calls them at different points in the application's lifetime. Some functions have special names and are called [lifecycle callbacks](/build/lifecycle-events-and-callbacks/), and you can also define arbitrarily named functions of your own to serve as your zome's API.
+A zome is just a [WebAssembly module](https://webassembly.github.io/spec/core/syntax/modules.html) that exposes public functions. The **conductor** (the Holochain runtime) knows about these functions and calls them at different points in the application's lifetime. Some functions have special names and are called **lifecycle callbacks**<!-- TODO uncomment when lifecycle callbacks PR is merged [lifecycle callbacks](/build/lifecycle-events-and-callbacks/)-->, and you can also define arbitrarily named functions of your own to serve as your zome's API.
 
 For Rust developers, we've created an SDK called the [Holochain Development Kit (HDK)](https://crates.io/crates/hdk/). It lets you define functions, exchange data with the host (the Holochain VM), and access all of the host's functionality.
 
@@ -20,7 +20,7 @@ An **integrity zome** defines a portion of your application's data model or sche
 
 !!! info Keep your integrity zomes small
 
-While you can define arbitrary public zome functions in your integrity zome, in practice it makes fixing bugs and adding features difficult, because every code change to an integrity zome [modifies the hash of the DNA](/build/application-structure/#dnas) and causes a fork of the database. So it's better for maintainability if the integrity zome _only_ contains your data model and the necessary callbacks that inform Holochain about that model.
+While you can define arbitrary public zome functions in your integrity zome, in practice it makes fixing bugs and adding features difficult, because every code change to an integrity zome [modifies the hash of the DNA](/build/application-structure/#dna) and causes a fork of the database. So it's better for maintainability if the integrity zome _only_ contains your data model and the necessary callbacks that inform Holochain about that model.
 
 Because these callbacks only need a small portion of Holochain's functionality, you don't need the entire `hdk` crate to write an integrity zome. Use the smaller [`hdi`](https://crates.io/crates/hdi) crate instead.
 
@@ -139,6 +139,6 @@ pub fn check_age_for_18a_movie(age: u32) -> ExternResult<()> {
 ## Further reading
 
 * [Build Guide: Lifecycle Events and Callbacks](/build/lifecycle-events-and-callbacks/)
-* [Build Guide: Zome Functions](/build/zome-functions/)
+<!-- TODO: uncomment after zome functions PR is merged * [Build Guide: Zome Functions](/build/zome-functions/)-->
 * [WebAssembly](https://webassembly.org/)
 * [serde](https://serde.rs/)

--- a/src/pages/build/zomes.md
+++ b/src/pages/build/zomes.md
@@ -32,9 +32,48 @@ Your integrity zome tells Holochain about the types of [entries](/build/entries/
 
 Finally, your integrity zome defines [validation callbacks](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) that check for correctness of data and actions. Holochain runs this on an agent's own device when they attempt to author data, and on other peers' devices when they're asked to store and serve data authored by others.
 
+#### Create an integrity zome
+
+**The easy way to create an integrity zome** is to [scaffold a new hApp](/get-started/3-forum-app-tutorial/). The scaffolding tool will generate all the project files, including scripts to test and build distributable packages, and it can also scaffold boilerplate code for all your app's required callbacks and data types.
+
+If you want to start from scratch, first make sure you have Rust, Cargo, and the `wasm32-unknown-unknown` Rust toolchain installed on your computer. Then create a library crate:
+
+```bash
+cargo new my_integrity_zome --lib
+```
+
+Then add some necessary dependencies to your new `Cargo.toml` file:
+
+```diff:toml
+ [dependencies]
++hdi = "=0.5.0-rc.1"
++serde = "1.0"
+```
+
+At the very minimum, make sure your code exposes a [`validate` callback](/build/lifecycle-events-and-callbacks/#define-a-validate-callback) and [defines some entry types](/build/entries/#define-an-entry-type).
+
+Compile your zome using `cargo`:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
+```
+
 ### Coordinator
 
 Coordinator zomes hold your back-end logic --- the functions that read and write data or communicate with peers. In addition to some optional, specially named [lifecycle callbacks](/build/lifecycle-events-and-callbacks/#coordinator-zomes), you can also write your own **zome functions** that serve as your zome's API.
+
+#### Create a coordinator zome
+
+Again, **the easiest way to create a coordinator zome** is to let the scaffolding tool do it for you. But if you want to do it from scratch, it's the same as an integrity zome, with two exceptions. Your `Cargo.toml`'s dependencies should be modified like this:
+
+```diff:toml
+ [dependencies]
+-hdi = "=0.5.0-rc.1"
++hdk = "=0.4.0-rc.1"
+ serde = "1.0"
+```
+
+And there aren't any required callbacks to define in your code.
 
 ## Define a function
 

--- a/src/pages/concepts/3_source_chain.md
+++ b/src/pages/concepts/3_source_chain.md
@@ -63,7 +63,7 @@ This journal starts with three special system records, followed optionally by so
 1. The **DNA hash**. Because the DNA's executable code constitutes the 'rules of the game' for a network of participants, this record claims that your Holochain runtime has seen and is abiding by those rules.
 2. The agent's **membrane proof**. When a cell tries to join a network, it shares this entry with the existing peers, who check it and determine whether the cell should be allowed to join them. Examples: an invite code, an employee ID signed by the HR department, or a proof of paid subscription fees.
 3. The **agent ID**. This contains your public key as your digital identity. The signatures on all subsequent records must match this public key in order to be valid.
-4. Zero or more records containing application data that was written during the init process --- that is, by the `init` [lifecycle callback](../11_lifecycle_events) of any coordinator zomes that define one.
+4. Zero or more records containing application data that was written during the init process --- that is, by the `init` [lifecycle hook](../11_lifecycle_events) of any coordinator zomes that define one.
 4. The **init complete** action. This is a record meant for internal use, simply helping the conductor remind itself that it's completely activated the cell by running all the coordinator zomes' `init` callbacks.
 
 After this come the records that record the user's actions. These include:

--- a/src/pages/concepts/3_source_chain.md
+++ b/src/pages/concepts/3_source_chain.md
@@ -54,7 +54,7 @@ The user's actions are stored in the source chain as **records**, which consist 
 
 It's most helpful to think of an action as just that --- the _act of changing application state_. So instead of thinking of a source chain record as "a chat message", for instance, you could think of it as recording "the act of adding a chat message to your feed". So while it's useful for noun-like things like messages and images, it is also well-suited to things like real-time document edits, game moves, and transactions. You'll learn about all the different action types in the section on [CRUD](../6_crud_actions/) --- actions like 'create link' and 'delete entry'.
 
-This journal starts with three special system records, followed optionally by some app data, and one final system record:
+This journal starts with three special system records called **genesis records**, followed optionally by some app data, and one final system record:
 
 ![](/assets/img/concepts/3.3-genesis-records-1-and-2.png){.sz60p} {.center}
 
@@ -64,7 +64,7 @@ This journal starts with three special system records, followed optionally by so
 2. The agent's **membrane proof**. When a cell tries to join a network, it shares this entry with the existing peers, who check it and determine whether the cell should be allowed to join them. Examples: an invite code, an employee ID signed by the HR department, or a proof of paid subscription fees.
 3. The **agent ID**. This contains your public key as your digital identity. The signatures on all subsequent records must match this public key in order to be valid.
 4. Zero or more records containing application data that was written during the init process --- that is, by the `init` [lifecycle hook](../11_lifecycle_events) of any coordinator zomes that define one.
-4. The **init complete** action. This is a record meant for internal use, simply helping the conductor remind itself that it's completely activated the cell by running all the coordinator zomes' `init` callbacks.
+5. The **init complete** action. This is a record meant for internal use, simply helping the conductor remind itself that it's completely activated the cell by running all the coordinator zomes' `init` callbacks.
 
 After this come the records that record the user's actions. These include:
 

--- a/src/pages/concepts/3_source_chain.md
+++ b/src/pages/concepts/3_source_chain.md
@@ -122,7 +122,7 @@ Holochain's answer is simple --- _somebody will notice_. More on that in the nex
 * Data is stored in the source chain as records, which consist of actions and sometimes entries.
 * Data can be linked together.
 * Every entry and link has a type, validated by a function that checks its integrity in the context of its place in the source chain.
-* The first four entries are called genesis entries, and are special system types that contain the DNA hash, the agent's membrane proof, their public key, and an init-complete marker.
+* The first four records on a source chain are called genesis records, and are special system types that contain the DNA hash, the agent's membrane proof, their public key, and an init-complete marker.
 * Entries are just binary data, and MessagePack is a good way to give them structure.
 * The source chain and all of its data is tamper-evident; validators can detect third-party attempts to modify it.
 

--- a/src/pages/resources/glossary.md
+++ b/src/pages/resources/glossary.md
@@ -436,7 +436,6 @@ The four records at the beginning of an [agent's](#agent) [source chain](#source
 1. The [DNA hash](#dna-hash), which shows that the agent has seen the network's rules and agrees to abide by them,
 2. The [membrane proof](#membrane-proof), which the agent presents as a claim that they should be allowed to join the [DHT](#distributed-hash-table-dht),
 3. The [agent ID](#agent-id), which advertises the agent's [public key](#public-key-cryptography),
-4. The [init complete action](#init-complete-action), which tells the conductor that all the DNA's [init callbacks](#init-callback) have completed successfully and the source chain is ready to have [app entries](#app-entry) written to it.
 
 #### Global consensus
 


### PR DESCRIPTION
Two pages here, with some cleanup/extra examples on the CRUD pages now that we've described the call-zome lifecycle and relaxed chain top ordering in detail. Depends on #511 and shouldn't be merged until that one is merged.

(Apologies to reviewers; somehow some fixes that were supposed to get added to another PR got added to this one instead.)