### PR TITLE
fix: un-squodge two sections on the build guide TOC

### DIFF
--- a/src/pages/build/index.md
+++ b/src/pages/build/index.md
@@ -51,6 +51,7 @@ Now that you've got some basic concepts and the terms we use for them, it's time
 * [Calling zome functions](/build/calling-zome-functions/) --- examples for front ends, cell-to-cell, and agent-to-agent
 * [Capabilities](/build/capabilities/) --- how to manage access to a cell's zome functions
 * [Signals](/build/signals) --- receiving notifications from cells
+:::
 
 ## Validation
 


### PR DESCRIPTION
It's literally four characters, one of which is a newline.