### PR TITLE
Chore: laundry list of fixes for 0.5

### DIFF
--- a/src/pages/resources/upgrade/upgrade-holochain-0.5.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.5.md
@@ -292,7 +292,7 @@ If you want to use these features, [build a custom Holochain binary](https://git
 
 ### `AppBundleSource::Bundle` removed
 
-**Note: This information is only relevant if you're building a runtime or using Tryorama's [`Conductor.prototype.installApp`](https://github.com/holochain/tryorama/blob/main/docs/tryorama.conductor.installapp.md) method.** The `Bundle` option (deprecated in 0.4.2) is now removed from [`AppBundleSource`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html). If you need to pass bundle bytes to the admin API's `InstallApp` endpoint, use [`AppBundleSource::Bytes`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html#variant.Bytes) (introduced in 0.4.2) and pass the bytes of an entire hApp bundle file instead.
+**Note: This information is only relevant if you're building a runtime or using Tryorama's [`Conductor.prototype.installApp`](https://github.com/holochain/tryorama/blob/main/docs/tryorama.conductor.installapp.md) method, either directly or through a helper like `scenario.addPlayersWithApps`.** The `Bundle` option (deprecated in 0.4.2) is now removed from [`AppBundleSource`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html). If you need to pass bundle bytes to the admin API's `InstallApp` endpoint, use [`AppBundleSource::Bytes`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html#variant.Bytes) (introduced in 0.4.2) and pass the bytes of an entire hApp bundle file instead.
 
 Note that, as a conductor API endpoint, `InstallApp` is also affected by [the enum serialization change](#enums-in-the-conductor-ap-is-are-serialized-differently):
 

--- a/src/pages/resources/upgrade/upgrade-holochain-0.5.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.5.md
@@ -215,6 +215,19 @@ This won't catch all errors; you may discover some at runtime. Look for usage of
 * [`AppWebsocket.disableCloneCell`](https://github.com/holochain/holochain-client-js/blob/v0.19.0/docs/client.appwebsocket.disableclonecell.md) and [`AppWebsocket.enableCloneCell`](https://github.com/holochain/holochain-client-js/blob/v0.19.0/docs/client.appwebsocket.enableclonecell.md), which now take a new [`CloneCellId`](https://github.com/holochain/holochain-client-js/blob/v0.19.0/docs/client.clonecellid.md) type for their `clone_id` argument
 * [`Signal`](https://github.com/holochain/holochain-client-js/blob/v0.19.0/docs/client.signal.md)
 
+### `AppWebsocket::callZome` can no longer accept a `null` cap secret
+
+The `cap_secret` field in the `request` argument of [`AppWebsocket::callZome`](https://github.com/holochain/holochain-client-js/blob/v0.19.0/docs/client.appwebsocket.callzome.md) can no longer be `null` --- instead it must either be omitted (you don't need it at all if your UI is hosted by an [officially supported Holochain runtime](/get-started/4-packaging-and-distribution/)) or explicitly given.
+
+```diff:typescript
+ const results = await client.value.callZome({
+     role_name: "my_dna",
+     zome_name: "my_zome",
+     fn_name: "foo",
+     payload: null,
+-    cap_secret: null,
+ });
+```
 
 ### `origin_time` and `quantum_time` are removed
 

--- a/src/pages/resources/upgrade/upgrade-holochain-0.5.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.5.md
@@ -188,7 +188,7 @@ The admin and app APIs have changed their serialization of enum variants with va
  client.on("signal", (sig: Signal) => {
 -    if (SignalType.App in sig) {
 -        const signal = sig[SignalType.App];
-+    if (sig.type == "app") {
++    if (sig.type == SignalType.App) {
 +        const signal = sig.value;
          // ... Handle the app signal
      }
@@ -292,7 +292,7 @@ If you want to use these features, [build a custom Holochain binary](https://git
 
 ### `AppBundleSource::Bundle` removed
 
-**Note: This information is only relevant if you're building a runtime or using Tryorama's [`Conductor.prototype.installApp`](https://github.com/holochain/tryorama/blob/main/docs/tryorama.conductor.installapp.md) method, either directly or through a helper like `scenario.addPlayersWithApps`.** The `Bundle` option (deprecated in 0.4.2) is now removed from [`AppBundleSource`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html). If you need to pass bundle bytes to the admin API's `InstallApp` endpoint, use [`AppBundleSource::Bytes`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html#variant.Bytes) (introduced in 0.4.2) and pass the bytes of an entire hApp bundle file instead.
+**Note: This information is only relevant if you're building a runtime or using Tryorama's [`Conductor.prototype.installApp`](https://github.com/holochain/tryorama/blob/v0.18.1/docs/tryorama.conductor.installapp.md) method, either directly or through a helper like `scenario.addPlayersWithApps`.** The `Bundle` option (deprecated in 0.4.2) is now removed from [`AppBundleSource`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html). If you need to pass bundle bytes to the admin API's `InstallApp` endpoint, use [`AppBundleSource::Bytes`](https://docs.rs/holochain_types/0.5.2/holochain_types/app/enum.AppBundleSource.html#variant.Bytes) (introduced in 0.4.2) and pass the bytes of an entire hApp bundle file instead.
 
 Note that, as a conductor API endpoint, `InstallApp` is also affected by [the enum serialization change](#enums-in-the-conductor-ap-is-are-serialized-differently):
 

--- a/src/pages/resources/upgrade/upgrade-holochain-0.5.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.5.md
@@ -354,7 +354,7 @@ The `NetworkInfo` endpoint of the app API has been removed, which means the `App
 
 ### Networking section of conductor config changed
 
-**Note: This only applies if you're using persistent conductor configs.** The `network` section of `conductor-config.yaml` files has changed. We recommend that you generate a new conductor config using `hc sandbox`, then compare it against your existing conductor config to see what changes need to be made. You can find available config keys in the [`NetworkConfig` documentation](https://docs.rs/holochain_conductor_api/0.5.2/holochain_conductor_api/config/conductor/struct.NetworkConfig.html).<!-- FIXME: get actual final release version into the URI - -->
+**Note: This only applies if you're using persistent conductor configs.** The `network` section of `conductor-config.yaml` files has changed. We recommend that you generate a new conductor config using `hc sandbox`, then compare it against your existing conductor config to see what changes need to be made. You can find available config keys in the [`NetworkConfig` documentation](https://docs.rs/holochain_conductor_api/0.5.2/holochain_conductor_api/config/conductor/struct.NetworkConfig.html).
 
 ### Admin API's `AgentInfo` return value changed
 

--- a/src/pages/resources/upgrade/upgrade-holochain-0.5.md
+++ b/src/pages/resources/upgrade/upgrade-holochain-0.5.md
@@ -117,8 +117,8 @@ Update the `hdk` and `hdi` version strings in the project's root `Cargo.toml` fi
  [workspace.dependencies]
 -hdi = "=0.5.2"
 -hdk = "=0.4.2"
-+hdi = "=0.6.1" # Pick a later patch version of these libraries if you prefer.
-+hdk = "=0.5.1"
++hdi = "=0.6.2" # Pick a later patch version of these libraries if you prefer.
++hdk = "=0.5.2"
 ```
 
 The latest version numbers of these libraries can be found on crates.io: [`hdi`](https://crates.io/crates/hdi), [`hdk`](https://crates.io/crates/hdk).
@@ -155,7 +155,7 @@ Edit your project's `tests/package.json` file:
 -    "@holochain/client": "^0.18.1",
 -    "@holochain/tryorama": "^0.17.1",
 +    "@holochain/client": "^0.19.0",
-+    "@holochain/tryorama": "^0.18.0",
++    "@holochain/tryorama": "^0.18.1",
      // more dependencies
    },
 ```
@@ -325,7 +325,7 @@ The `Timestamp` type used all over the HDK and in scaffolded entry types has bee
  # ...
  [dependencies]
 -kitsune_p2p_timestamp = "0.4.2"
-+holochain_timestamp = "0.5.1"
++holochain_timestamp = "0.5.2"
 ```
 
 ```diff:rust
@@ -343,7 +343,7 @@ The `NetworkInfo` endpoint of the app API has been removed, which means the `App
 
 ### Networking section of conductor config changed
 
-**Note: This only applies if you're using persistent conductor configs.** The `network` section of `conductor-config.yaml` files has changed. We recommend that you generate a new conductor config using `hc sandbox`, then compare it against your existing conductor config to see what changes need to be made. You can find available config keys in the [`NetworkConfig` documentation](https://docs.rs/holochain_conductor_api/0.5.0/holochain_conductor_api/config/conductor/struct.NetworkConfig.html).<!-- FIXME: get actual final release version into the URI - -->
+**Note: This only applies if you're using persistent conductor configs.** The `network` section of `conductor-config.yaml` files has changed. We recommend that you generate a new conductor config using `hc sandbox`, then compare it against your existing conductor config to see what changes need to be made. You can find available config keys in the [`NetworkConfig` documentation](https://docs.rs/holochain_conductor_api/0.5.2/holochain_conductor_api/config/conductor/struct.NetworkConfig.html).<!-- FIXME: get actual final release version into the URI - -->
 
 ### Admin API's `AgentInfo` return value changed
 


### PR DESCRIPTION
* More/better documentation for enum serialisation changes
* `cap_secret` can't be null
* bump version numbers, point to versioned JSDoc