### PR TITLE
Chore: allow 'edit' commit type

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,2 @@
+[commit_types]
+edit = { changelog_title = "", omit_from_changelog = true }


### PR DESCRIPTION
Just getting annoyed with cocogitto disliking my most common commit type, so I'm allowing it for this repo.